### PR TITLE
update maven version according branch name in Android doc

### DIFF
--- a/android_guide.md
+++ b/android_guide.md
@@ -66,25 +66,25 @@ dependencies {
     compile 'com.android.support:support-v4:21.0.3'
 
     //avoscloud-sdk 为 LeanCloud基础包
-    compile 'cn.leancloud.android:avoscloud-sdk:2.6.+'
+    compile 'cn.leancloud.android:avoscloud-sdk:v2.6.+'
 
     //avoscloud-push 与 Java-WebSocket 为推送与IM需要的包
-    compile 'cn.leancloud.android:avoscloud-push:2.6.+@aar'
+    compile 'cn.leancloud.android:avoscloud-push:v2.6.+@aar'
     compile 'cn.leancloud.android:Java-WebSocket:1.2.0-leancloud'
     
     //avoscloud-statistics 为 LeanCloud 统计包
-    compile 'cn.leancloud.android:avoscloud-statistics:2.6.+@aar'
+    compile 'cn.leancloud.android:avoscloud-statistics:v2.6.+@aar'
 
     //avoscloud-feedback 为 LeanCloud 用户反馈包
-    compile 'cn.leancloud.android:avoscloud-feedback:2.6.+@aar'
+    compile 'cn.leancloud.android:avoscloud-feedback:v2.6.+@aar'
 
     //avoscloud-sns 为 LeanCloud 第三方登陆包
-    compile 'cn.leancloud.android:avoscloud-sns:2.6.+@aar'
+    compile 'cn.leancloud.android:avoscloud-sns:v2.6.+@aar'
     compile 'cn.leancloud.android:qq-sdk:1.6.1-leancloud'
     compile 'cn.leancloud.android:weibo-sdk-android-sso:1.0.0-leancloud'
 
     //avoscloud-search 为 LeanCloud 应用内搜索包
-    compile 'cn.leancloud.android:avoscloud-search:2.6.+@aar'    
+    compile 'cn.leancloud.android:avoscloud-search:v2.6.+@aar'
 }
 ```
 


### PR DESCRIPTION
见[用户工单](https://ticket.avosapps.com/tickets/54d9809ae4b0a613535b3fc6/threads)，maven 仓库中最新版本的 jar 包版本都是以 v为前缀开头的(我们的分支名)，文档中示例有误，讲得不到最新版本

@sdjcw @lbt05 
