### PR TITLE
修复 REST API 文档中的 typo

### DIFF
--- a/md/js_guide.md
+++ b/md/js_guide.md
@@ -2441,5 +2441,5 @@ if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
 这种时候才需要用 Remote debugger 方式在手机上直接调试 WebView。
 这样做会大大节省你开发调试的时间，不然如果界面都通过 Remote debugger 方式开发，可能效率较低。
 
-4、为了防止通过 Javascript 反射调用 Java 代码访问 Android 文件系统的安全漏洞，在 Android 4.2以后的系统中间，WebView 中间只能访问通过[@JavascriptInterface](http://developer.android.com/reference/android/webkit/JavascriptInterface.html)标记过的方法。如果你的目标用户覆盖 4.2 以上的机型，请注意加上这个标记，以避免出现 "Uncaught TypeError"
+4、为了防止通过 JavaScript 反射调用 Java 代码访问 Android 文件系统的安全漏洞，在 Android 4.2以后的系统中间，WebView 中间只能访问通过[@JavascriptInterface](http://developer.android.com/reference/android/webkit/JavascriptInterface.html)标记过的方法。如果你的目标用户覆盖 4.2 以上的机型，请注意加上这个标记，以避免出现 "Uncaught TypeError"
 

--- a/md/rest_api.md
+++ b/md/rest_api.md
@@ -2,7 +2,7 @@
 
 REST API可以让您用任何可以发送HTTP请求的设备来与 LeanCloud 进行交互,您可以使用REST API做很多事情,比如:
 
-* 一个移动网站可以通过Javascript来获取 LeanCloud 上的数据.
+* 一个移动网站可以通过 JavaScript 来获取 LeanCloud 上的数据.
 * 一个网站可以展示来自 LeanCloud 的数据。
 * 您可以上传大量的数据,之后可以被一个移动app读取。
 * 您可以下载最近的数据来进行您自定义的分析统计。
@@ -374,7 +374,7 @@ REST API可以让您用任何可以发送HTTP请求的设备来与 LeanCloud 进
 
 用户验证是通过HTTP header来进行的, __X-AVOSCloud-Application-Id__ 头标明正在运行的是哪个App程序, 而 __X-AVOSCloud-Application-Key__ 头用来授权鉴定endpoint.在下面的例子中,您的app的key被包含在命令中,您可以使用下拉框来显示其他app的示例代码.
 
-对于Javascript使用,LeanCloud 支持跨域资源共享,所以您可以将这些header同XMLHttpRequest一同使用。
+对于 JavaScript 使用, LeanCloud 支持跨域资源共享,所以您可以将这些header同XMLHttpRequest一同使用。
 
 
 #### 更安全的鉴权方式
@@ -2701,4 +2701,4 @@ Strict-Transport-Security: max-age=31536000
 {}
 ```
 
-总之，就是利用POST传递的参数，把 `_method` ，`_ApplicationId` 以及 `_ApplicationKey` 传递给服务端，服务端会自动把这些请求翻译成指定的方法，这样可以使得 Unity3D 以及 Javascript 等平台（或者语言）可以绕开浏览器跨域或者方法限制。
+总之，就是利用POST传递的参数，把 `_method` ，`_ApplicationId` 以及 `_ApplicationKey` 传递给服务端，服务端会自动把这些请求翻译成指定的方法，这样可以使得 Unity3D 以及 JavaScript 等平台（或者语言）可以绕开浏览器跨域或者方法限制。


### PR DESCRIPTION
当上下文表示 JavaScript 这门语言时，应该使用 "JavaScript"。

参考链接：[1995 年，Netscape 和 Sun 联合宣布该语言，命名为 JavaScript](https://web.archive.org/web/20070916144913/http://wp.netscape.com/newsref/pr/newsrelease67.html)。