### PR TITLE
LeanEngine: 解决 appid 等变量无法渲染的问题

### DIFF
--- a/views/leanengine_guide.tmpl
+++ b/views/leanengine_guide.tmpl
@@ -1,3 +1,7 @@
+{% set appid = '{{appid}}' %}
+{% set appkey = '{{appkey}}' %}
+{% set masterkey = '{{masterkey}}' %}
+
 # LeanEngine 指南
 
 ## 介绍


### PR DESCRIPTION
因为 LeanEngine 使用 nunjucks 来生成多份文档的 md 文件，这一步会导致
`{{appid}}` 这样的变量直接被替换为空（因为 nunjucks 上下文没有该变量）。

现在使用一个变通的办法：在模板文件最上方先定义出来 appid 等几个变量，
其值为 '{{appid}}'。