### PR TITLE
评论插件：打包时增加 snipetContent 上传；localBuild 不执行 comment 任务

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,3 +1,4 @@
+'use strict';
 var lrSnippet = require('grunt-contrib-livereload/lib/utils').livereloadSnippet;
 var proxySnippet = require("grunt-connect-proxy/lib/utils").proxyRequest;
 var mountFolder = function(connect, dir) {
@@ -240,7 +241,7 @@ module.exports = function(grunt) {
    "less:dist", "autoprefixer", "cssmin", "copy:asset",
     "useminPrepare",'concat:generated',
     'uglify:generated',"usemin"]);
-  grunt.registerTask("localBuild",["clean", "copy:md", "markdown", "assemble","comment",
+  grunt.registerTask("localBuild",["clean", "nunjucks", "copy:md", "markdown", "assemble",
    "less:dist", "autoprefixer", "copy:asset"]);
   grunt.registerTask("server", ["localBuild", "less:server","configureProxies", "connect:livereload", "watch"]);
 
@@ -249,93 +250,114 @@ module.exports = function(grunt) {
 
 
     grunt.registerMultiTask('comment','add version info',function(){
+      grunt.task.requires('assemble');
       // console.log('comment task',this.files,this.filesSrc);
       var cheerio = require('cheerio');
       var crypto = require('crypto');
-      var Q = require('q');
+      var _ = require('underscore');
       var AV = require('avoscloud-sdk').AV;
       AV.initialize("749rqx18p5866h0ajv0etnq4kbadodokp9t0apusq98oedbb", "axxq0621v6pxkya9qm74lspo00ef2gq204m5egn7askjcbib");
+      // test project
+      //AV.initialize("0siycem2w0l2zem2z5crxl7602zkf1r2a8qsooigq2my1al1", "4ipiwns1939nw2cgist4s49li89dvadrlrgthfvqmgzcaax5");
       var Doc = AV.Object.extend('Doc');
+      var Snippet = AV.Object.extend('Snippet');
       var commentDoms = ['p','pre'];
       var done = this.async();
 
-      var sequence = Q.resolve();
+      function initDocVersion(filepath, allSnippetsVersion){
+        var file = filepath;
+        var content = grunt.file.read(filepath);
+        var $ = cheerio.load(content);
+        var docVersion = crypto.createHash('md5').update($('#content').text()).digest('hex');
+        // console.log(docVersion)
+        $('html').first().attr('version', docVersion);
 
-      var  allPromise = [];
-
-      function initDocVersion(filepath,resolve,reject){
-          var file = filepath;
-          var content = grunt.file.read(filepath);
-
-          // console.log(docVersion)
-          var $ = cheerio.load(content);
-
-          var docVersion = crypto.createHash('md5').update($('#content').text()).digest('hex');
-          $('html').first().attr('version', docVersion);
-
-          //以 docversion 为唯一标识，当文档内容发生变化，docversion 相应变化，
-          var query = new AV.Query(Doc);
-          query.equalTo('version', docVersion);
-          query.first().then(function(doc) {
-            if (!doc) {
-              doc = new Doc();
-              doc.set('version', docVersion);
-              var snippets = [];
-              commentDoms.forEach(function(dom) {
-                $('#content ' + dom).each(function() {
-                  var version = crypto.createHash('md5').update($(this).text()).digest('hex');
-                  snippets.push({version: version});
-                });
-              });
-              doc.set('snippets', snippets);
-            }
-            //文件名，以及段落 snippet 信息更新
-            doc.set('file', file.split('/').pop());
-
-            return new Q.Promise(function(resolve1,reject1){
-              doc.save().then(function(){
-                resolve1();
-              },function(){
-                reject1();
-              })
+        //以 docversion 为唯一标识，当文档内容发生变化，docversion 相应变化，
+        var query = new AV.Query(Doc);
+        query.equalTo('version', docVersion);
+        return query.first().then(function(doc) {
+          if (doc) {
+            // 如果 doc 已经存在，则直接返回
+            return AV.Promise.as();
+          }
+          doc = new Doc();
+          doc.set('version', docVersion);
+          var snippets = [];
+          commentDoms.forEach(function(dom) {
+            $('#content ' + dom).each(function() {
+              var version = crypto.createHash('md5').update($(this).text()).digest('hex');
+              snippets.push({version: version});
             });
-          },function(){
-            return Q.resolve();
-          }).then(function() {
-            // 在文档中添加 version 标记
-            commentDoms.forEach(function(dom) {
-              $('#content ' + dom).each(function() {
-                // console.log(2)
-                var version = crypto.createHash('md5').update($(this).text()).digest('hex');
-                $(this).attr('version', version);
-              });
+          });
+          doc.set('snippets', snippets);
+          //文件名，以及段落 snippet 信息更新
+          doc.set('file', file.split('/').pop());
+          grunt.log.writeln('save new Doc: %s', file);
+          return doc.save();
+        }).then(function() {
+          // 在文档中添加 version 标记
+          commentDoms.forEach(function(dom) {
+            $('#content ' + dom).each(function() {
+              var version = crypto.createHash('md5').update($(this).text()).digest('hex');
+              $(this).attr('version', version);
             });
-            grunt.file.write(filepath, $.html());
-            resolve();
-          // done();
-        },function(){
-          reject();
+          });
+          grunt.file.write(filepath, $.html());
+          return AV.Promise.as();
+        }).then(function() {
+          var promises = [];
+          // 保存 snippet version 和 content 的关联
+          commentDoms.forEach(function(dom) {
+            $('#content ' + dom).each(function() {
+              var version = crypto.createHash('md5').update($(this).text()).digest('hex');
+              if(_.contains(allSnippetsVersion, version)) {
+                return;
+              }
+              grunt.log.writeln('save new Snippet: %s', $(this).text().substr(0, 20) + '...');
+              promises.push(new Snippet().save({
+                snippetVersion: version,
+                content: $(this).text(),
+                file: filepath.split('/').pop()
+              }));
+            });
+          });
+          return AV.Promise.all(promises);
         });
       }
-
-      this.filesSrc.forEach(function(filepath) {
-
-        allPromise.push(new Q.Promise(function(resolve,reject){
-          initDocVersion(filepath,resolve,reject)
-        }));
+      var self = this;
+      // 查询所有已存在的 snippet version，
+      // 用来判断哪些是新的 snipeet，然后将其 version 和 content 添加到数据库
+      var snippetsVersion = [];
+      var getSnippetsVersion = function(skip) {
+        return AV.Query.doCloudQuery('select snippetVersion from Snippet limit ?, ?', [skip, 1000]).then(function(result) {
+          if(result.results.length === 0) {
+            return AV.Promise.as();
+          }
+          _.each(result.results, function(snippet) {
+            snippetsVersion.push(snippet.get('snippetVersion'));
+          });
+          return getSnippetsVersion(snippetsVersion.length);
+        });
+      };
+      getSnippetsVersion(0).then(function() {
+        grunt.log.writeln('current snippets count:', snippetsVersion.length);
+        var allPromise = [];
+        self.filesSrc.forEach(function(filepath) {
+          allPromise.push(initDocVersion(filepath, snippetsVersion));
+        });
+        return AV.Promise.all(allPromise);
+      }).then(function() {
+        //保证所有文档都处理完再进行任务完成回调
+        grunt.log.writeln('version build allcompleted');
+        done();
+      }, function(err) {
+        grunt.log.error('err: %s', err.stack || err.message || err);
+        done();
+      }).catch(function(err){
+        grunt.log.error('err: %s', err.stack || err.message || err);
+        done();
       });
-      //保证所有文档都处理完再进行任务完成回调
-      Q.all(allPromise).then(function(){
-        console.log('version build allcompleted');
-        done();
-      },function(){
-        console.log('error happened');
-        done();
-      }).catch(function(){
-        console.log('error');
-        done();
-      })
   });
 
 
-}
+};

--- a/package.json
+++ b/package.json
@@ -17,13 +17,19 @@
   "devDependencies": {
     "assemble": "~0.4.33",
     "assemble-swig": "~0.1.0",
+    "avoscloud-sdk": "^0.5.4",
+    "body-parser": "^1.13.1",
+    "cheerio": "^0.19.0",
+    "coffee-script": "^1.9.3",
     "connect-livereload": "~0.3.1",
+    "cookie-parser": "^1.3.5",
+    "express": "^4.13.0",
     "grunt": "~0.4.2",
     "grunt-autoprefixer": "~0.5.0",
+    "grunt-connect-proxy": "0.1.10",
     "grunt-contrib-clean": "~0.5.0",
     "grunt-contrib-concat": "~0.5.1",
     "grunt-contrib-connect": "~0.5.0",
-    "grunt-connect-proxy": "0.1.10",
     "grunt-contrib-copy": "~0.4.1",
     "grunt-contrib-cssmin": "~0.7.0",
     "grunt-contrib-less": "~0.8.3",
@@ -32,20 +38,10 @@
     "grunt-contrib-watch": "~0.6.1",
     "grunt-dom-munger": "^3.4.0",
     "grunt-markdown": "~0.7.0",
+    "grunt-nunjucks": "git://github.com/sdjcw/grunt-nunjucks-render.git",
     "grunt-usemin": "~3.0.0",
     "nunjucks": "^1.3.4",
-
-    "grunt-nunjucks": "git://github.com/sdjcw/grunt-nunjucks-render.git",
-    "cheerio": "^0.19.0",
-    "avoscloud-sdk": "^0.5.4",
-    "q": "1.4.1",
-    "body-parser": "^1.13.1",
-    "coffee-script": "^1.9.3",
-    "cookie-parser": "^1.3.5",
-    "express": "^4.13.0",
     "underscore": "^1.8.3"
   },
-  "dependencies": {
-
-  }
+  "dependencies": {}
 }


### PR DESCRIPTION
* 打包时上传 snippetVersion 和 content 的关联关系：这一步查询所有 snippetVersion 有点慢（5 秒左右，会查询到 6000+ 个 version），查询完成输出日志：
  
  ```
  current snippets count: 6294
  ```
  如果有新的 snippet 保存，会输出类似的日志：
  
  ```
  save new Snippet: 由于一个用户一次登录只能加入一个聊天室，...
  ```
* localBuild 任务不会执行 comment 命令，防止开发阶段的 snippet 和 doc 上传。
* localBuild 任务增加 `nunjucks` 动作，使得多渲染文档能够生成 md，并最终渲染成 html
* 如果 doc 已经存在，则不再更新。之前 293 行会保存，我觉得没有必要。
* 使用 AV 自带的 promise，而不是 `Q` 组件：我们默认有 promise，而且够用，所以重写了很多逻辑。‘

@sunchanglong 麻烦 review 下。