### PR TITLE
更新安卓推送文档

### DIFF
--- a/md/android_push_guide.md
+++ b/md/android_push_guide.md
@@ -77,7 +77,7 @@ AVInstallation.getCurrentInstallation().saveInBackground();
 
 ### 配置
 
-请确保你的 AndroidManifest.xml 包含如下内容
+请确保你的 AndroidManifest.xml 的`<application>`中包含如下内容
 ```xml
 <service android:name="com.avos.avoscloud.PushService"
   android:exported="true"/>


### PR DESCRIPTION
`<service ../>`需要加在`<application>`中

一开始看完文档加在`<manifest>`下了, 然后发现log里一直说PushService无法启动, 看了demo的项目才知道加错了，感觉改一下对初学者还是方便不少。其实文档里给一个完整的manifest文件可能更直观一些。