### PR TITLE
fix(docs): fix a wrong param in retrieving conversation history 

### DIFF
--- a/views/realtime_guide-android.md
+++ b/views/realtime_guide-android.md
@@ -1609,7 +1609,7 @@ conversationQuery.whereEqualTo("topic", "DOTA2");
 
         // 获取第一页的消息里面最旧的一条消息
         AVIMMessage pager = firstPage.get(0);
-        conversation.queryMessages(pager.getMessageId(), pager.getReceiptTimestamp(), pageSize, new AVIMMessagesQueryCallback() {
+        conversation.queryMessages(pager.getMessageId(), pager.getTimestamp(), pageSize, new AVIMMessagesQueryCallback() {
           @Override
           public void done(List<AVIMMessage> secondPage, AVIMException e) {
             // secondPage 就是第二页的数据


### PR DESCRIPTION
查询历史记录的第二个参数，如果按照文档所写，使用getReceiptTimestamp() 则无法正确查询到历史记录，而使用getTimestamp() 就能正确查询。前者是对方收到消息的时间，后者是发送消息的时间。（2015-11-19T07:12:53.764Z by	ibookpa_tc）