### PR TITLE
Add codesign in Run Script

### DIFF
--- a/md/start/ios_start.md
+++ b/md/start/ios_start.md
@@ -103,6 +103,8 @@ find "$APP_PATH" -name '*.framework' -type d | while read -r FRAMEWORK; do
 
     mv "$FRAMEWORK_EXECUTABLE_PATH-merged" "$FRAMEWORK_EXECUTABLE_PATH"
     rm "${EXTRACTED_ARCHS[@]}"
+
+    /usr/bin/codesign -f -s "${CODE_SIGN_IDENTITY}" $FRAMEWORK
 done
 ```
 


### PR DESCRIPTION
在 Run Script 中添加一个强制签名的步骤，用于动态库 SDK 的集成。 @leancloud/objective-c 