### PR TITLE
fix(docs): 补充 Android 统计/应用权限配置的示例代码

### DIFF
--- a/md/android_statistics.md
+++ b/md/android_statistics.md
@@ -15,31 +15,32 @@
 
 请务必确保你的应用拥有如下权限：
 
-* `android.permission.INTERNET`
+* `android.permission.INTERNET`<br/>
   向 LeanCloud 的统计服务器发送用户分析数据。
-* `android.permission.READ_PHONE_STATE`
-  `android.permission.ACCESS_WIFI_STATE`
+* `android.permission.READ_PHONE_STATE`<br/>
+  `android.permission.ACCESS_WIFI_STATE`<br/>
   这两个权限是为了获取用户手机的 IMEI 以及 WiFi 的 Mac 地址，用来唯一的标识用户。
-* `android.permission.ACCESS_NETWORK_STATE`
+* `android.permission.ACCESS_NETWORK_STATE`<br/>
   检测网络状态。
-* `android.permission.READ_LOGS`
+* `android.permission.READ_LOGS`<br/>
   获取客户端 crash log。通过将 crash log 汇报到服务器上，你可以了解你的应用 crash 的原因以及次数。
-* `android.permission.WRITE_EXTERNAL_STORAGE`
+* `android.permission.WRITE_EXTERNAL_STORAGE`<br/>
   保存离线报告的缓存数据。
 
 示例：
 
 ```xml
-<manifest ……>
-    <application ……>
-        ……
-        <activity ……/>
+<manifest ...>
+    <application ...>
+        ...
+        <activity .../>
     </application>
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.READ_PHONE_STATE" />
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
+    <uses-permission android:name="android.permission.READ_LOGS" />
 </manifest>
 ```
 


### PR DESCRIPTION
android.permission.READ_LOGS 漏掉了