### PR TITLE
edit the annotation of  action for signature

### DIFF
--- a/md/realtime_v2.md
+++ b/md/realtime_v2.md
@@ -326,7 +326,7 @@ appid:clientid:convid:sorted_member_ids:timestamp:nonce:action
 
 * appid、clientid、sorted_member_ids、timestamp 和 nonce  的含义同上。对加入群的情况，这里 sorted_member_ids 是空字符串。
 * convid - 此次行为关联的对话 id。
-* action - 此次行为的动作，行为分别对应常量 **invite**（加群和邀请）和 **kick**（踢出群）。
+* action - 此次行为的动作，分为 **add** （加群和邀请）与 **remove** （踢出群）两种，但出于兼容考虑，签名时分别使用常量 **invite** 和 **kick** 来进行表示。
 
 ## 云引擎 Hook
 


### PR DESCRIPTION

服务端为了兼容老版本，不得不使用了与新版本 action 不一致的字段，给用户造成了困扰，详情见工单：


![2015-12-04 12 01 04](https://cloud.githubusercontent.com/assets/2911921/11565779/7ff14288-9a1a-11e5-9fbe-cf395fc5c9ed.png)


故在文档和 SDK 层面做下注释说明。

iOS-SDK 也做了注释说明 ： https://github.com/leancloud/ios-sdk/pull/577