### PR TITLE
Update sns.md

### DIFF
--- a/md/sns.md
+++ b/md/sns.md
@@ -64,6 +64,19 @@ AVOSCloudSNS 是一个非常轻量的模块, 可以用最少一行代码就可�
 -(BOOL)application:(UIApplication *)application handleOpenURL:(NSURL *)url{
     return [AVOSCloudSNS handleOpenURL:url];
 }
+
+// When Build with IOS 9 SDK
+// For application on system below ios 9
+- (BOOL)application:(UIApplication *)application openURL:(NSURL *)url sourceApplication:(NSString *)sourceApplication annotation:(id)annotation
+{
+    return [AVOSCloudSNS handleOpenURL:url];
+}
+// For application on system equals or larger ios 9
+- (BOOL)application:(UIApplication *)app openURL:(NSURL *)url options:(NSDictionary<NSString *,id> *)options
+{
+    return [AVOSCloudSNS handleOpenURL:url];
+}
+
 ```
 
 这样，代码部分就完成了。


### PR DESCRIPTION
ios9 中第三方的handleUrl取消了handleOpenUrl， 使用以上方法在xcode 7 中编译出来的代码，没有办法实现第三方应用调用
请替换成以上两种方法

