### PR TITLE
fix(docs): REST API 获取聊天记录需要 masterkey 权限

### DIFF
--- a/md/realtime_rest_api.md
+++ b/md/realtime_rest_api.md
@@ -74,7 +74,7 @@ curl -X PUT \
 ```sh
 curl -X GET \
   -H "X-LC-Id: {{appid}}" \
-  -H "X-LC-Key: {{appkey}}" \
+  -H "X-LC-Key: {{masterkey}},master" \
   https://leancloud.cn/1.1/rtm/messages/logs
 ```
 


### PR DESCRIPTION
这里应该用master key，否则会报401错误