### PR TITLE
fix(docs): 删除 iOS 本地缓存查询的重复语句

### DIFF
--- a/views/realtime_guide.tmpl
+++ b/views/realtime_guide.tmpl
@@ -788,8 +788,6 @@ Black 发现对话名字不够酷，他想修改成「聪明的喵星人」 ，�
 
 {% block code_set_query_policy %}{% endblock %}
 
-有时你希望先走网络查询，发生网络错误的时候，再从本地查询，可以这样：
-
 {% block code_query_from_local_cache %}{% endblock %}
 
 各种查询缓存策略的行为可以参考 {% block link_avquery_chache %}{% endblock %}


### PR DESCRIPTION
目前只有 iOS 文档对此功能提供了代码，所以这次先从主模板里去掉这句话。