### PR TITLE
更新云引擎的二级域名

### DIFF
--- a/md/cloud_code_commandline.md
+++ b/md/cloud_code_commandline.md
@@ -264,7 +264,7 @@ Production commit log  : 'Uploaded at 2014-10-09 16:56:06'
 $ avoscloud deploy -o '测试本地推送部署'
 ```
 
-部署之后，你可以通过 curl 命令，或者访问你设置的 `xxxx.avosapps.com` 的二级域名对应的专用测试域名 `dev.xxx.avosapps.com` 测试你的云引擎代码。
+部署之后，你可以通过 curl 命令，或者访问你设置的 `${your_app_domain}.leanapp.cn` 的二级域名对应的专用测试域名 `stg-${your_app_domain}.leanapp.cn` 测试你的云引擎代码。
 
 ### Git 仓库部署
 

--- a/md/js_realtime.md
+++ b/md/js_realtime.md
@@ -417,7 +417,7 @@ var realtimeObject = AV.realtime({
 realtimeObject.on('open', function() {
    console.log('与服务器连接成功！');
 });
-// http://jsplay.avosapps.com/rot/embed?js,console
+// http://jsplay.leanapp.cn/rot/embed?js,console
 ```
 
 ### AV.realtime.version

--- a/md/realtime.md
+++ b/md/realtime.md
@@ -8,7 +8,7 @@
 
 * 一个完整的社交应用 `LeanChat`，类似微信，[LeanChat-Android](https://github.com/leancloud/leanchat-android)，[LeanChat-iOS](https://github.com/leancloud/leanchat-ios)
 * [JavaScript Demo](https://github.com/leancloud/leanmessage-javascript-sdk/tree/master/demo)
-* 便于调试的 [在线测试工具](http://chat.avosapps.com/)。
+* 便于调试的 [在线测试工具](http://chat.leanapp.cn/)。
 
 
 ## 功能和特性

--- a/md/tool_tips.md
+++ b/md/tool_tips.md
@@ -105,7 +105,7 @@
 * 通过 [工单系统](https://ticket.leancloud.cn/login) 提交技术支持申请，获取 LeanCloud 工程师的帮助。
 * 在右上角用户名左侧的消息中心，可以看到 LeanCloud 最火热的新闻和教程。
 * 在工具栏的资源菜单里，可以找到 LeanCloud 移动客户端下载链接，在移动设备上查看应用分析数据。
-* 使用 [drop](https://drop.avosapps.com/) 或者 [fir.im](http://fir.im/) 分发测试你的应用。
+* 使用 [drop](https://drop.leanapp.cn/) 或者 [fir.im](http://fir.im/) 分发测试你的应用。
 * 我们提供 [离线文档](leancloud-docs.tar.gz) 下载。
 * 不知道怎么使用 LeanCloud？各种 [Demo](demo.html) 等你来拿。
 * [文档搜索工具](/search.html)，查找问题或资料不用愁。

--- a/views/leanengine_guide-cloudcode.md
+++ b/views/leanengine_guide-cloudcode.md
@@ -153,7 +153,7 @@ require('cloud/app.js');
 {% endblock %}
 
 {% block demo %}
-* [cloudcode-test](https://github.com/killme2008/cloudcode-test)：一个简单留言板网站。效果体验：<https://myapp.avosapps.com/>
+* [cloudcode-test](https://github.com/killme2008/cloudcode-test)：一个简单留言板网站。效果体验：<https://myapp.leanapp.cn/>
 {% endblock %}
 
 {% block run_in_local_command %}
@@ -597,11 +597,11 @@ AV.Cloud.define('Logger', function(request, response) {
 {% block static_cache %}
 ### 静态资源
 
-`public` 目录下的资源将作为静态文件服务，例如，`public/index.html` 就可以通过 `http://${your_app_domain}.avosapps.com/index.html` 访问到这个文件。
+`public` 目录下的资源将作为静态文件服务，例如，`public/index.html` 就可以通过 `http://${your_app_domain}.leanapp.cn/index.html` 访问到这个文件。
 
 通常，你会将资源文件按照类型分目录存放，比如 css 文件放在 `stylesheets` 目录下，将图片放在 `images` 目录下，将 javascript 文件放在 `js` 目录下，云引擎同样能支持这些目录的访问。
 
-例如，`public/stylesheets/app.css` 可以通过 `http://${your_app_domain}.avosapps.com/stylesheets/app.css` 访问到。
+例如，`public/stylesheets/app.css` 可以通过 `http://${your_app_domain}.leanapp.cn/stylesheets/app.css` 访问到。
 
 在你的HTML文件里引用这些资源文件，使用相对路径即可，比如在 `public/index.html` 下引用 `app.css`：
 
@@ -660,7 +660,7 @@ app.listen();
 app.set('view engine', 'jade');
 ```
 
-你可以参照上面的 [部署](#部署) 章节来部署这个框架代码，部署成功之后，直接可以访问 `http://${your_app_domain}.avosapps.com/hello` 将看到展示的 message：
+你可以参照上面的 [部署](#部署) 章节来部署这个框架代码，部署成功之后，直接可以访问 `http://${your_app_domain}.leanapp.cn/hello` 将看到展示的 message：
 
 ```
 Congrats, you just set up your app!
@@ -668,7 +668,7 @@ Congrats, you just set up your app!
 
 更多复杂的路由和参数传递，请看 [express.js 框架文档](http://expressjs.com/guide.html)。
 
-我们还提供了一个在线 Demo：<http://myapp.avosapps.com/>，[源码](https://github.com/killme2008/cloudcode-test) 开放供大家参考。
+我们还提供了一个在线 Demo：<http://myapp.leanapp.cn/>，[源码](https://github.com/killme2008/cloudcode-test) 开放供大家参考。
 {% endblock %}
 
 {% block error_page_404 %}

--- a/views/leanengine_guide-node.md
+++ b/views/leanengine_guide-node.md
@@ -25,8 +25,8 @@ $ avoscloud add <appName> <appId>
 {% endblock %}
 
 {% block demo %}
-* [node-js-getting-started](https://github.com/leancloud/node-js-getting-started)：这是一个非常简单的基于 Express 4 的项目，可以作为大家的项目模板。（在线演示：<http://node.avosapps.com/>） 
-* [leanengine-todo-demo](https://github.com/leancloud/leanengine-todo-demo)：这是一个稍微复杂点的项目，是上一个项目的扩展，演示了基本的用户注册、会话管理、业务数据的增删查改、简单的 ACL 使用。这个项目可以作为初学云引擎和 [JavaScript SDK](js_guide.html) 使用。（在线演示：<http://todo-demo.avosapps.com/>）
+* [node-js-getting-started](https://github.com/leancloud/node-js-getting-started)：这是一个非常简单的基于 Express 4 的项目，可以作为大家的项目模板。（在线演示：<http://node.leanapp.cn/>） 
+* [leanengine-todo-demo](https://github.com/leancloud/leanengine-todo-demo)：这是一个稍微复杂点的项目，是上一个项目的扩展，演示了基本的用户注册、会话管理、业务数据的增删查改、简单的 ACL 使用。这个项目可以作为初学云引擎和 [JavaScript SDK](js_guide.html) 使用。（在线演示：<http://todo-demo.leanapp.cn/>）
 * [LeanEngine-Full-Stack](https://github.com/leancloud/LeanEngine-Full-Stack) ：该项目是基于云引擎的 Web 全栈开发的技术解决方案，比较大型的 Web 项目可以使用这个结构实现从 0 到 1 的敏捷开发。
 {% endblock %}
 

--- a/views/leanengine_guide-python.md
+++ b/views/leanengine_guide-python.md
@@ -29,7 +29,7 @@ $ avoscloud add <APP-NAME> <APP-ID>
 {% block runtime_env %}**注意**：目前云引擎的 Python 版本为 2.7，请你最好使用此版本的 Python 进行开发。Python 3 的支持正在开发中。{% endblock %}
 
 {% block demo %}
-* [python-getting-started](https://github.com/leancloud/python-getting-started)：这是一个非常简单的 Python Web 的项目，可以作为大家的项目模板。（在线演示：<http://python.avosapps.com/>）
+* [python-getting-started](https://github.com/leancloud/python-getting-started)：这是一个非常简单的 Python Web 的项目，可以作为大家的项目模板。（在线演示：<http://python.leanapp.cn/>）
 {% endblock %}
 
 {% block run_in_local_command %}

--- a/views/leanengine_guide.tmpl
+++ b/views/leanengine_guide.tmpl
@@ -58,7 +58,7 @@ curl -X POST -H "Content-Type: application/json; charset=utf-8"   \
 $ avoscloud deploy
 ```
 
-如果你设置了 [二级域名](#设置域名)，即可通过 `http://dev.${your_app_domain}.avosapps.com` 访问你应用的测试环境。
+如果你设置了 [二级域名](#设置域名)，即可通过 `http://stg-${your_app_domain}.leanapp.cn` 访问你应用的测试环境。
 
 部署到生产环境：
 
@@ -66,7 +66,7 @@ $ avoscloud deploy
 $ avoscloud publish
 ```
 
-如果你设置了 [二级域名](#设置域名)，即可通过 `http://${your_app_domain}.avosapps.com` 访问你应用的生产环境。
+如果你设置了 [二级域名](#设置域名)，即可通过 `http://${your_app_domain}.leanapp.cn` 访问你应用的生产环境。
 
 通过下列命令可以确认云函数在云引擎上工作正常：
 
@@ -608,7 +608,7 @@ crontab 的基本语法是：
 
 这一切都需要你去创建一个 web 应用，并且从 VPS 厂商那里购买一个虚拟主机来运行 web 应用，你可能还需要去购买一个域名。
 
-不过现在，云引擎为你提供了网站托管功能，可以让你为应用设置一个二级域名 `xxx.avosapps.com`（美国区为 `xxx.avosapps.us` ），并把你的 web 应用部署到该域名之下运行，同时支持静态资源和动态请求服务。
+不过现在，云引擎为你提供了网站托管功能，可以让你为应用设置一个二级域名 `${your_app_domain}.leanapp.cn`（美国区为 `${your_app_domain}.avosapps.us` ），并把你的 web 应用部署到该域名之下运行，同时支持静态资源和动态请求服务。
 
 ### 设置域名
 
@@ -618,7 +618,7 @@ crontab 的基本语法是：
 
 上面将应用的二级域名设置为 **myapp**，设置之后，你应该可以马上访问：
 
-- http://myapp.avosapps.com
+- http://myapp.leanapp.cn
 - http://myapp.avosapps.us
 
 可能因为 DNS 生效延迟暂时不可访问，请耐心等待或者尝试刷新 DNS 缓存，如果还没有部署，你看到的应该是一个 404 页面。
@@ -635,7 +635,7 @@ crontab 的基本语法是：
 
 其他用户如果需要为应用绑定一个独立域名，可以使用账户注册邮箱将下列信息发送至 <support@leancloud.cn>，或者从控制台菜单中选择 [帮助 / 技术支持](https://ticket.leancloud.cn/)，通过工单来提出申请：
 
-* 你已经绑定的 avosapps.com 或 avosapps.us 二级子域名（请参考设置域名）
+* 你已经绑定的 leanapp.cn 或 avosapps.us 二级子域名（请参考设置域名）
 * 要绑定的域名（必须是你名下的域名）
 * 你的注册邮箱（必须与发送者的邮箱一致）
 * 你想要绑定的 App Id（该应用必须位于注册邮箱的用户名下）
@@ -643,7 +643,7 @@ crontab 的基本语法是：
 
 我们会在 3 个工作日内完成审核，如果审核通过将为你绑定域名。请在绑定操作完成后配置 DNS：
 
-- 将要绑定域名的 CNAME 或者 A 记录指向 avosapps.com（国内）或 avosapps.us（美国）
+- 将要绑定域名的 CNAME 或者 A 记录指向 leanapp.cn（国内）或 avosapps.us（美国）
 
 #### 域名备案流程
 
@@ -802,7 +802,7 @@ WAP<br/>
 
 为了安全性，我们可能会为网站加上 HTTPS 加密传输。我们的云引擎支持网站托管，同样会有这样的需求。
 
-因此我们在云引擎中提供了一个新的 middleware 来强制让你的 `${your_app_domain}.avosapps.com` 的网站通过 https 访问，你只要这样：
+因此我们在云引擎中提供了一个新的 middleware 来强制让你的 `${your_app_domain}.leanapp.cn` 的网站通过 https 访问，你只要这样：
 
 {% block https_redirect %}{% endblock %}
 
@@ -812,9 +812,9 @@ WAP<br/>
 
 前面已经谈到云引擎的测试和生产环境之间的区别，可以通过 HTTP 头部 `X-LC-Prod` 来区分。但是对于 网站托管 就没有办法通过这个HTTP头来方便的区分。
 
-因此，我们其实为每个应用创建了两个域名，除了 `xxx.avosapps.com` 之外，每个应用还有 `dev.xxx.avosapps.com` 域名作为测试环境的域名。
+因此，我们其实为每个应用创建了两个域名，除了 `${your_app_domain}.leanapp.cn` 之外，每个应用还有 `stg-${your_app_domain}.leanapp.cn` 域名作为测试环境的域名。
 
-部署的测试代码将运行在这个域名之上，在测试通过之后，通过菜单 **部署** / **部署到生产环境** 按钮切换之后，可以在 `xxx.avosapps.com` 看到最新的运行结果。
+部署的测试代码将运行在这个域名之上，在测试通过之后，通过菜单 **部署** / **部署到生产环境** 按钮切换之后，可以在 `${your_app_domain}.leanapp.cn` 看到最新的运行结果。
 
 ## 第三方平台接入
 


### PR DESCRIPTION
issue https://github.com/leancloud/cloud-code/issues/481

我把找到的 `avosapps.com` 的地方都换成了 `leanapp.cn`。

另外把 `xxx.avosapps.com` 这类说明都改成了 `${your_app_domain}.leanapp.cn`，因为 xxx 看起来有点尴尬。。