### PR TITLE
fix(docs): 修复 AV.Query 初始化的语法

### DIFF
--- a/md/js_guide.md
+++ b/md/js_guide.md
@@ -173,7 +173,7 @@ post.save({
 在 LeanCloud 中保存数据是很简单的，获取数据也非常容易。如果事先知道 `objectId` 的话,你可以用一个 `AV.Query` 提取出整个 `AV.Object`:
 
 ```javascript
-var query = new AV.Query(Post);
+var query = new AV.Query('Post');
 query.get('558e20cbe4b060308e3eb36c', {
   success: function(post) {
     // 成功获得实例
@@ -495,7 +495,7 @@ AV.Object 实例的大小不应该超过 128 KB，如果需要存储较大的文
 回一个满足条件的 AV.Object 数组。例如，查询指定人员的微博信息，使用 `equalTo` 方法来添加条件值：
 
 ```javascript
-var query = new AV.Query(Post);
+var query = new AV.Query('Post');
 query.equalTo('pubUser', 'LeanCloud官方客服');
 query.find({
   success: function(results) {
@@ -561,7 +561,7 @@ query.limit(10); // 最多返回 10 条结果
 如果你只想要一个结果，一个更加方便的方法可能是使用 `first`，而不是 `find` 方法.
 
 ```javascript
-var query = new AV.Query(Post);
+var query = new AV.Query('Post');
 query.equalTo('pubUser', 'LeanCloud官方客服');
 query.first({
   success: function(object) {
@@ -641,10 +641,11 @@ postQuery.find({
 });
 ```
 
-相反，要从一个查询中获取一组对象，该对象的一个键值，与另一个对象的键值并不匹配，可以使用 `doesNotMatchKeyInQuery` 。
+相反，要从一个查询中获取一组对象，该对象的一个键值，与另一个对象的键值并不匹配，可以使用 `doesNotMatchKeyInQuery`。
 例如，找出当前用户没有关注的人发布的微博：
 
 ```javascript
+// Post 和 userQuery 在上段代码中已声明
 var postQuery = new AV.Query(Post);
 postQuery.doesNotMatchKeyInQuery('author', 'followee', userQuery);
 postQuery.find({
@@ -657,7 +658,7 @@ postQuery.find({
 你可以用 `select` 和一个 keys 的列表来限定返回的字段，为了获得只包含 pubUser 和 content 字段的微博（包括内置字段，如 objectId、createdAt、updatedAt）:
 
 ```javascript
-var query = new AV.Query(Post);
+var query = new AV.Query('Post');
 query.select('pubUser', 'content');
 query.find().then(function(results) {
   // each of results will only have the selected fields available.
@@ -702,7 +703,7 @@ query.sizeEqualTo('arrayKey', 3);
 
 ```javascript
 // 找出名字以 'LeanCloud' 开头的账户的微博帖子
-var query = new AV.Query(Post);
+var query = new AV.Query('Post');
 query.startsWith('pubUser', 'LeanCloud');
 ```
 
@@ -713,8 +714,8 @@ query.startsWith('pubUser', 'LeanCloud');
 例如，如果每条评论 `Comment` 的 `post` 字段都有一个 `Post` 微博对象，那么找出指定微博下的评论：
 
 ```javascript
-// Assume AV.Object myPost was previously created.
-var query = new AV.Query(Comment);
+// 假设类型为 AV.Object 的 myPost 已提前定义
+var query = new AV.Query('Comment');
 query.equalTo('post', myPost);
 query.find({
   success: function(comments) {
@@ -728,9 +729,9 @@ query.find({
 况。例如，为了找到有图片的微博的评论，你可以:
 
 ```javascript
-var innerQuery = new AV.Query(Post);
+var innerQuery = new AV.Query('Post');
 innerQuery.exists('image');
-var query = new AV.Query(Comment);
+var query = new AV.Query('Comment');
 query.matchesQuery('post', innerQuery);
 query.find({
   success: function(comments) {
@@ -743,9 +744,9 @@ query.find({
 `doesNotMatchQuery`。例如，为了找到针对不含图片的微博的评论，你可以这样：
 
 ```javascript
-var innerQuery = new AV.Query(Post);
+var innerQuery = new AV.Query('Post');
 innerQuery.exists('image');
-var query = new AV.Query(Comment);
+var query = new AV.Query('Comment');
 query.doesNotMatchQuery('post', innerQuery);
 query.find({
   success: function(comments) {
@@ -766,7 +767,7 @@ query.equalTo('post', post);
 法。比如，假设你想获得最新的 10 个 comments，你可能想同时获取它们相关的 post 数据:
 
 ```javascript
-var query = new AV.Query(Comment);
+var query = new AV.Query('Comment');
 
 // 最新的在前面
 query.addDescending('createdAt');
@@ -803,7 +804,7 @@ AV.Query 的 helper 函数，例如 `first` 和 `get` 等.
 如果你只是想查询满足一个 query 的结果集到底有多少对象，但是你不需要得到它们，你可以使用 `count` 来取代 `find`。比如，计算一下某位用户一共发布了多少条微博：
 
 ```javascript
-var query = new AV.Query(Post);
+var query = new AV.Query('Post');
 query.equalTo('pubUser', 'LeanCloud官方客服');
 query.count({
   success: function(count) {
@@ -1898,7 +1899,7 @@ post.set('author', user);
 post.save(null, {
   success: function(post) {
     // Find all posts by the current user
-    var query = new AV.Query(Post);
+    var query = new AV.Query('Post');
     query.equalTo('author', user);
     query.find({
       success: function(usersPosts) {
@@ -2102,7 +2103,7 @@ post.set('location', point);
 var userGeoPoint = userObject.get('location');
 
 // Create a query for posts
-var query = new AV.Query(Post);
+var query = new AV.Query('Post');
 
 // Interested in posts near user.
 query.near('location', userGeoPoint);
@@ -2127,7 +2128,7 @@ query.find({
 var point1 = new AV.GeoPoint(39.97, 116.33);
 var point2 = new AV.GeoPoint(39.99, 116.37);
 
-var query = new AV.Query(Post);
+var query = new AV.Query('Post');
 query.withinGeoBox('location', point1, point2);
 query.find({
   success: function(posts) {


### PR DESCRIPTION
用户评论：`var query = new AV.Query(Post);` 报错，只有给 Post 加上引号才通过。