### PR TITLE
feat(style): 增加自定义下划线样式，与加粗交替使用

### DIFF
--- a/custom/less/section-docs.less
+++ b/custom/less/section-docs.less
@@ -38,6 +38,13 @@ body {
     vertical-align: super;
     line-height: 0;
   }
+  
+  // text-underline
+  u {
+    text-decoration: none;
+	border-bottom: 1px solid #333;
+	padding-bottom: 2px;  
+  }
 }
 
 // Tables


### PR DESCRIPTION
用在文档正文中。使用 `<u>` 来标注，默认的 underline 效果不理想。