### PR TITLE
guide user not  to create conversation without client id

### DIFF
--- a/views/realtime_guide-ios.md
+++ b/views/realtime_guide-ios.md
@@ -1422,7 +1422,8 @@ NSDate *yesterday = [today dateByAddingTimeInterval: -86400.0];
     // Tom 打开 client
     [self.client openWithCallback:^(BOOL succeeded, NSError *error) {
         // Tom 创建名称为 「HelloKitty PK 加菲猫」的会话
-        [self.client createConversationWithName:@"HelloKitty PK 加菲猫" clientIds:@[] attributes:nil options:AVIMConversationOptionTransient callback:^(AVIMConversation *conversation, NSError *error) {
+        NSArray *friends = @[@"Jerry", @"Bob", @"Harry", @"William"];
+        [self.client createConversationWithName:@"HelloKitty PK 加菲猫" clientIds:friends attributes:nil options:AVIMConversationOptionTransient callback:^(AVIMConversation *conversation, NSError *error) {
             if (!error) {
                 NSLog(@"创建成功！");
             }


### PR DESCRIPTION
@leancloud/ios-group  @leancloud/docs-editor  @leancloud/push 


这里目前不能传空，如果传空，SDK就会拦截下来，抛出clientid是空的错误。

这里有两个修改方法，一个是SDK不做这层判断，传空的话，服务端会用创建者的id创建一个只有一个人的暂态会话。


另一个是修改下文档，不建议传空。


这里有一个场景，如果是“主播”自己创建暂态聊天室，他新创建一个号，既没有关注别人，也没人关注他。他想创聊天室，无法获取别人的 ClientId。主播创建聊天室的时候，先拉一个人进来是不大可能了。这种场景只能是主播自己把自己的id传进去了。需不需要在文档里把这个也说明下？