### PR TITLE
[网站托管开发指南 · Node.js] 大量细节修改

### DIFF
--- a/md/leanengine_quickstart.md
+++ b/md/leanengine_quickstart.md
@@ -112,19 +112,16 @@ app.get('/', function(req, res) {
 
 ## 部署到云端
 
-部署到预备环境：
+使用免费版的应用可以直接部署到生产环境：
 
 ```
 $ lean deploy
 ```
 
-如果你设置了 [二级域名](leanengine_webhosting_guide-node.html#设置域名)，即可通过 `http://stg-${your_app_domain}.leanapp.cn` 访问你应用的预备环境。
-
-部署到生产环境：
-
-```
-$ lean publish
-```
-
 如果你设置了 [二级域名](leanengine_webhosting_guide-node.html#设置域名)，即可通过 `http://${your_app_domain}.leanapp.cn` 访问你应用的生产环境。
 
+如果是专业版应用，`lean deploy` 会先部署到预备环境（`http://stg-${your_app_domain}.leanapp.cn`），你可以再运行一下 `lean publish` 来部署到生产环境：
+
+```
+$ lean deploy
+```

--- a/views/leanengine_webhosting_guide-node.md
+++ b/views/leanengine_webhosting_guide-node.md
@@ -21,13 +21,13 @@ app.get('/time', function(req, res) {
 {% block project_constraint %}
 {{fullName}} 项目必须有 `$PROJECT_DIR/server.js` 文件，该文件为整个项目的启动文件。
 
-**注意：**项目中**不能**有 `$PROJECT_DIR/cloud/main.js` 文件，否则会被识别为 [2.0 版本](./leanengine_guide-cloudcode.html#项目约束) 的项目。
+**注意：** 项目中 **不能** 有 `$PROJECT_DIR/cloud/main.js` 文件，否则会被识别为 [2.0 版本](./leanengine_guide-cloudcode.html#项目约束) 的项目。
 {% endblock %}
 
 {% block project_start %}
 ### 项目启动
 
-如果 `$PROJECT_DIR/package.json` 文件有类似下面的声明：
+如果 `$PROJECT_DIR/package.json` 文件有自定义的启动脚本：
 
 ```
 {
@@ -43,7 +43,7 @@ app.get('/time', function(req, res) {
 
 则会使用 `npm start` 方式启动。这意味着可以使用 [npm scripts](https://docs.npmjs.com/misc/scripts) 来定制启动过程。
 
-**提示：**有些遗留项目可能会将 `start` 脚本写成 `node ./app.js` 从而导致启动检测失败，所以将脚本改成 `node server.js` 或者你确认的启动方式即可。
+**提示：** 有些遗留项目可能会将 `start` 脚本写成 `node ./app.js` 从而导致启动检测失败，所以将脚本改成 `node server.js` 或者你确认的启动方式即可。
 
 如果没有 `start` 脚本，则默认使用 `node server.js` 来启动，所以需要保证存在 `$PROJECT_DIR/server.js` 文件。 {% endblock %}
 
@@ -51,16 +51,7 @@ app.get('/time', function(req, res) {
 {{leanengine_middleware}} 内置了该 URL 的处理，只需要将中间件添加到请求的处理链路中即可：
 
 ```
-app.use(AV.Cloud);
-```
-
-或者类似于 [项目框架](https://github.com/leancloud/node-js-getting-started) 那样，有一个 [cloud.js](https://github.com/leancloud/node-js-getting-started/blob/master/cloud.js) 且最终是以 `module.exports = AV.Cloud;` 结尾，然后在 [app.js](https://github.com/leancloud/node-js-getting-started/blob/master/app.js) 中加载 `cloud.js` 也可以达到一样的效果：
-
-```
-var cloud = require('./cloud');
-
-// 加载云引擎方法
-app.use(cloud);
+app.use(AV.express());
 ```
 
 如果未使用 {{leanengine_middleware}}，则需要自己实现该 URL 的处理，比如这样：
@@ -73,11 +64,16 @@ app.use('/__engine/1/ping', function(req, res) {
     "version": "custom"
   }));
 });
+
+// 云函数列表
+app.get('/1.1/_ops/functions/metadatas', function(req, res) {
+  res.end(JSON.stringify([]));
+});
 ```
 {% endblock %}
 
 {% block supported_frameworks %}
-{{fullName}} 支持任意 [Node.js](https://nodejs.org) 的 Web 框架，你可以使用你最熟悉的框架进行开发，或者不使用任何框架，直接使用 Node.js 的 http 模块进行开发。但是请保证通过执行 `server.js` 能够启动你的项目，启动之后程序监听的端口为 `process.env.LC_APP_PORT`。
+{{fullName}} 支持任意 [Node.js](https://nodejs.org) 的 Web 框架，你可以使用你最熟悉的框架进行开发，或者不使用任何框架，直接使用 Node.js 的 http 模块进行开发。但是请保证通过执行 `server.js` 能够启动你的项目，启动之后程序监听的端口为 `process.env.LEANCLOUD_APP_PORT`。
 
 ```js
 var express = require('express');
@@ -85,8 +81,8 @@ var AV = require('leanengine');
 
 var app = express();
 
-app.use(AV.Cloud);
-app.listen(process.env.LC_APP_PORT);
+app.use(AV.express());
+app.listen(process.env.LEANCLOUD_APP_PORT);
 ```
 {% endblock %}
 
@@ -107,182 +103,58 @@ app.get('/', function(req, res) {
 如果是自定义项目，则需要自己配置：
 
 * 配置依赖：在项目根目录下执行以下命令来增加 {{leanengine_middleware}} 的依赖：
-  ```
-  $ npm install leanengine --save
-  ```
+
+```
+$ npm install leanengine@next --save
+```
+
 * 初始化：在正式使用数据存储之前，你需要使用自己的应用 key 进行初始化中间件：
-  ```js
-  var AV = require('leanengine');
-  
-  var APP_ID = process.env.LC_APP_ID || '{{appid}}'; // 你的 app id
-  var APP_KEY = process.env.LC_APP_KEY || '{{appkey}}'; // 你的 app key
-  var MASTER_KEY = process.env.LC_APP_MASTER_KEY || '{{masterkey}}'; // 你的 master key
-  
-  AV.initialize(APP_ID, APP_KEY, MASTER_KEY);
-  // 如果不希望使用 masterKey 权限，可以将下面一行删除
-  AV.Cloud.useMasterKey();
-  ```
+
+```js
+var AV = require('leanengine');
+
+AV.init({
+  appId: process.env.LEANCLOUD_APP_ID || '{{appid}}', // 你的 app id
+  appKey: process.env.LEANCLOUD_APP_KEY || '{{appkey}}', // 你的 app key
+  masterKey: process.env.LEANCLOUD_APP_MASTER_KEY || '{{masterkey}}' // 你的 master key
+});
+
+// 如果不希望使用 masterKey 权限，可以将下面一行删除
+AV.Cloud.useMasterKey();
+```
 {% endblock %}
 
 {% block http_client %}
 
-**提示**：推荐使用 [request](https://www.npmjs.com/package/request) 等第三方模块来处理 HTTP 请求。
+推荐使用 [request](https://www.npmjs.com/package/request) 这个第三方模块来完成 HTTP 请求。
 
-云引擎允许你使用 `AV.Cloud.httpRequest` 函数来发送 HTTP 请求到任意的 HTTP 服务器。使用 `AV.Cloud.httpRequest` ，一个简单的 GET 请求看起来是这样：
+安装 request:
 
-```javascript
-AV.Cloud.httpRequest({
-  url: 'http://www.google.com/',
-  success: function(httpResponse) {
-    console.log(httpResponse.text);
-  },
-  error: function(httpResponse) {
-    console.error('Request failed with response code ' + httpResponse.status);
-  }
-});
+```sh
+npm install request --save
 ```
 
-当返回的 HTTP 状态码是成功的状态码（例如 200、201 等），则 success 函数会被调用，反之 error 函数将被调用。
-
-#### 查询参数
-
-如果你想添加查询参数到 URL 末尾，你可以设置选项对象的 params 属性。你既可以传入一个 JSON 格式的 key-value 对象，像这样：
+代码示例：
 
 ```javascript
-AV.Cloud.httpRequest({
-  url: 'http://www.google.com/search',
-  params: {
-    q : 'Sean Plott'
-  },
-  success: function(httpResponse) {
-    console.log(httpResponse.text);
-  },
-  error: function(httpResponse) {
-    console.error('Request failed with response code ' + httpResponse.status);
-  }
-});
-```
+var request = require('request');
 
-也可以是一个原始的字符串：
-
-```javascript
-AV.Cloud.httpRequest({
-  url: 'http://www.google.com/search',
-  params: 'q=Sean Plott',
-  success: function(httpResponse) {
-    console.log(httpResponse.text);
-  },
-  error: function(httpResponse) {
-    console.error('Request failed with response code ' + httpResponse.status);
-  }
-});
-```
-
-#### 设置 HTTP 头部
-
-通过设置选项对象的 header 属性，你可以发送 HTTP 头信息。假设你想设定请求的 `Content-Type`，你可以这样做：
-
-```javascript
-AV.Cloud.httpRequest({
-  url: 'http://www.example.com/',
-  headers: {
-    'Content-Type': 'application/json'
-  },
-  success: function(httpResponse) {
-    console.log(httpResponse.text);
-  },
-  error: function(httpResponse) {
-    console.error('Request failed with response code ' + httpResponse.status);
-  }
-});
-```
-
-#### 设置超时
-
-默认请求超时设置为 10 秒，超过这个时间没有返回的请求将被强制终止，你可以通过 timeout 选项（单位毫秒）调整这个超时，比如把请求超时设置为 15 秒：
-
-```javascript
-AV.Cloud.httpRequest({
-  url: 'http://www.example.com/',
-  timeout: 15000,
-  headers: {
-    'Content-Type': 'application/json'
-  },
-  success: function(httpResponse) {
-    console.log(httpResponse.text);
-  },
-  error: function(httpResponse) {
-    console.error('Request failed with response code ' + httpResponse.status);
-  }
-});
-```
-
-
-#### 发送 POST 请求
-
-通过设置选项对象的 method 属性就可以发送 POST 请求。同时可以设置选项对象的 body 属性来发送数据，例如：
-
-```javascript
-AV.Cloud.httpRequest({
+request({
   method: 'POST',
   url: 'http://www.example.com/create_post',
-  body: {
+  json: {
     title: 'Vote for Pedro',
     body: 'If you vote for Pedro, your wildest dreams will come true'
-  },
-  success: function(httpResponse) {
-    console.log(httpResponse.text);
-  },
-  error: function(httpResponse) {
-    console.error('Request failed with response code ' + httpResponse.status);
+  }
+}, function(err, res, body) {
+  if (err) {
+    console.error('Request failed with response code ' + res.statusCode);
+  } else {
+    console.log(body);
   }
 });
 ```
 
-这将会发送一个 POST 请求到 `http://www.example.com/create_post`，body 是被 URL 编码过的表单数据。 如果你想使用 JSON 编码 body，可以这样做：
-
-```javascript
-AV.Cloud.httpRequest({
-  method: 'POST',
-  url: 'http://www.example.com/create_post',
-  headers: {
-    'Content-Type': 'application/json'
-  },
-  body: {
-    title: 'Vote for Pedro',
-    body: 'If you vote for Pedro, your wildest dreams will come true'
-  },
-  success: function(httpResponse) {
-    console.log(httpResponse.text);
-  },
-  error: function(httpResponse) {
-    console.error('Request failed with response code ' + httpResponse.status);
-  }
-});
-```
-
-当然，body 可以被任何想发送出去的 String 对象替换。
-
-#### HTTP 应答对象
-
-传给 success 和 error 函数的应答对象包括下列属性：
-
-- **status**：HTTP 状态码
-- **headers**：HTTP 应答头部信息
-- **text**：原始的应答 body 内容
-- **buffer**：原始的应答 Buffer 对象
-- **data**：解析后的应答内容，如果云引擎可以解析返回的 `Content-Type` 的话（例如 JSON 格式，就可以被解析为一个 JSON 对象）
-
-如果你不想要 text（会消耗资源做字符串拼接），只需要 buffer，那么可以设置请求的 text 选项为 false：
-
-```javascript
-AV.Cloud.httpRequest({
-  method: 'POST',
-  url: 'http://www.example.com/create_post',
-  text: false,
-  ......
-});
-```
 {% endblock %}
 
 {% block upload_file_special_middleware %}
@@ -305,11 +177,10 @@ app.post('/upload', function(req, res){
         if(err) {
           return res.send('读取文件失败');
         }
-        var base64Data = data.toString('base64');
-        var theFile = new AV.File(iconFile.originalFilename, {base64: base64Data});
+        var theFile = new AV.File(iconFile.originalFilename, data);
         theFile.save().then(function(theFile){
           res.send('上传成功！');
-        });
+        }).catch(console.error);
       });
     } else {
       res.send('请选择一个文件。');
@@ -322,7 +193,7 @@ app.post('/upload', function(req, res){
 {% block cookie_session %}
 ### 处理用户登录和登出
 
-要让云引擎支持 LeanCloud 用户体系的 Session，在 app.js 里添加下列代码：
+云引擎提供了一个 `AV.Cloud.CookieSession` 中间件，用 Cookie 来维护用户（`AV.User`）的登录状态，要使用这个中间件可以在 `app.js` 中添加下列代码：
 
 ```javascript
 var express = require('express');
@@ -333,63 +204,62 @@ var app = express();
 app.use(AV.Cloud.CookieSession({ secret: 'my secret', maxAge: 3600000, fetchUser: true }));
 ```
 
-使用 `AV.Cloud.CookieSession` 中间件启用 CookieSession，注意传入一个 secret 用于 cookie 加密（必须）。它会自动将 `AV.User` 的登录信息记录到 cookie 里，用户每次访问会自动检查用户是否已经登录，如果已经登录，可以通过 `req.AV.user` 获取当前登录用户。
+你需要传入一个 secret 用于加密 Cookie（必须提供），这个中间件会将 `AV.User` 的登录状态信息记录到 Cookie 中，用户下次访问时自动检查用户是否已经登录，如果已经登录，可以通过 `req.currentUser` 获取当前登录用户。
 
 `AV.Cloud.CookieSession` 支持的选项包括：
 
 * **fetchUser**：**是否自动 fetch 当前登录的 AV.User 对象。默认为 false。**  
-  如果设置为 true，每个 HTTP 请求都将发起一次 LeanCloud API 调用来 fetch 用户对象。如果设置为 false，默认只可以访问 `req.AV.user` 当前用户的 id 属性（即 _User 表记录的 ObjectId），你可以在必要的时候 fetch 整个用户。通常保持默认的 false 就可以。
-* **name**：session 在 cookie 中存储的 key 名称，默认为 `avos.sess`。
-* **maxAge**：设置 cookie 的过期时间。
+  如果设置为 true，每个 HTTP 请求都将发起一次 LeanCloud API 调用来 fetch 用户对象。如果设置为 false，默认只可以访问 `req.currentUser` 的 `id`（`_User` 表记录的 ObjectId）和 `sessionToken` 属性，你可以在需要时再手动 fetch 整个用户。
+* **name**：Cookie 的名字，默认为 `avos.sess`。
+* **maxAge**：设置 Cookie 的过期时间。
 
-`httpOnly` 和 `signed` 参数我们强制设置为 true。
+**注意**：在 Node SDK 1.x 之后我们不再允许通过 `AV.User.current()` 获取登录用户的信息（详见 [升级到云引擎 Node.js SDK 1.0](leanengine-node-sdk.html)）：
 
-**注意**：我们通常不建议在云引擎环境中通过 `AV.User.current()` 获取登录用户的信息，虽然这样做不会有问题，也不会有串号的风险，但由于这个功能依赖 Node.js 的 Domain 模块，而 Node.js 4.x 已经不推荐使用 Domain 模块了，所以在云引擎中获取 currentUser 的机制后续会发生改变。因此，我们建议：
-
-* 在云引擎方法中，通过 `request.user` 获取用户信息。
-* 在网站托管中，通过 `req.AV.user` 获取用户信息。
+* 在云引擎方法中，通过 `request.currentUser` 获取用户信息。
+* 在网站托管中，通过 `request.currentUser` 获取用户信息。
 * 在后续的方法调用显示传递 user 对象。
 
-登录很简单：
+你可以这样简单地实现一个具有登录功能的站点：
 
 ```javascript
+// 渲染登录页面
 app.get('/login', function(req, res) {
-  // 渲染登录页面
   res.render('login.ejs');
 });
-// 点击登录页面的提交将出发下列函数
+
+// 处理登录请求（可能来自登录界面中的表单）
 app.post('/login', function(req, res) {
   AV.User.logIn(req.body.username, req.body.password).then(function(user) {
-    //登录成功，AV.Cloud.CookieSession 会自动将登录用户信息存储到 cookie
-    //跳转到profile页面。
     console.log('signin successfully: %j', user);
-    res.redirect('/profile');
+    res.saveCurrentUser(user); // 保存当前用户到 Cookie.
+    res.redirect('/profile'); // 跳转到个人资料页面
   },function(error) {
     //登录失败，跳转到登录页面
     res.redirect('/login');
   });
-});
-//查看用户profile信息
+})
+
+// 查看个人资料
 app.get('/profile', function(req, res) {
   // 判断用户是否已经登录
-  if (req.AV.user) {
+  if (req.currentUser) {
     // 如果已经登录，发送当前登录用户信息。
-    res.send(req.AV.user);
+    res.send(req.currentUser);
   } else {
     // 没有登录，跳转到登录页面。
     res.redirect('/login');
   }
 });
 
-//调用此 url 来登出账号
+// 登出账号
 app.get('/logout', function(req, res) {
-  // AV.Cloud.CookieSession 将自动清除登录 cookie 信息
-  AV.User.logOut();
+  req.currentUser.logOut();
+  res.clearCurrentUser(); // 从 Cookie 中删除用户
   res.redirect('/profile');
 });
 ```
 
-登录页面大概是这样 login.ejs:
+一个简单的登录页面（`login.ejs`）可以是这样：
 
 ```html
 <html>
@@ -406,12 +276,13 @@ app.get('/logout', function(req, res) {
   </html>
 ```
 
-注意：express 框架的 `express.session.MemoryStore` 在我们云引擎中是无法正常工作的，因为我们的云引擎是多主机，多进程运行，因此内存型 session 是无法共享的，建议用 [express.js &middot; cookie-session 中间件](https://github.com/expressjs/cookie-session)。
 {% endblock %}
 
 {% block custom_session %}
 ### 自定义 session
 有时候你需要将一些自己需要的属性保存在 session 中，你可以增加通用的 `cookie-session` 组件，详情可以参考 [express.js &middot; cookie-session](https://github.com/expressjs/cookie-session)。该组件和 `AV.Cloud.CookieSession` 组件可以并存。
+
+注意：express 框架的 `express.session.MemoryStore` 在我们云引擎中是无法正常工作的，因为我们的云引擎是多主机、多进程运行，因此内存型 session 是无法共享的，建议用 [express.js &middot; cookie-session 中间件](https://github.com/expressjs/cookie-session)。
 {% endblock %}
 
 {% block https_redirect %}
@@ -437,7 +308,7 @@ app.use(AV.Cloud.HttpsRedirect());
 
 **提示**：{{productName}} 0.12 和 4.x 差异较大，建议升级后充分测试。
 
-**提示**：如果 {{productName}} 不支持所指定的版本，则会默认使用 {{platformName}} 4.x 版本。
+**提示**：如果 {{productName}} 不支持所指定的版本，则会默认使用 {{platformName}} 0.12 版本。
 {% endblock %}
 
 {% block get_env %}

--- a/views/leanengine_webhosting_guide.tmpl
+++ b/views/leanengine_webhosting_guide.tmpl
@@ -4,7 +4,7 @@
 {% set var_app_domain = '{应用的域名}' %}
 # 网站托管开发指南 &middot; {{platformName}}
 
-使用你熟悉的语言开发一个 web 程序，提供静态和动态路由，开发一个 web 站点，拥有自己的二级域名；或者为移动应用提供一个介绍和下载页；或者开发一个管理员控制台。
+使用你熟悉的语言开发一个 Web 程序，提供静态文件托管和动态路由，开发一个 Web 站点，拥有自己的二级域名；或者为移动应用提供一个介绍和下载页；或者开发一个管理员控制台。
 
 网站托管是云引擎的一个子模块，请确保在阅读本文档之前，你已阅读了 [云引擎服务概览](leanengine_overview.html)。
 
@@ -30,7 +30,7 @@
 
 ### 健康监测
 
-云引擎项目在部署启动时，部署服务会对新启动的应用进行 `ping` 监测（每隔 1 秒请求一次，一共 15 次），请求 URL 为 `/__engine/1/ping`，如果响应的 `statusCode` 为 `200` 则认为新的节点启动成功，整个部署才会成功；否则会收到 **应用启动检测失败** 类型的错误信息，导致部署失败。
+云引擎项目在部署启动时，部署服务会对新启动的应用进行 `ping` 监测（每隔 1 秒请求一次，一共 30 次），请求 URL 为 `/__engine/1/ping`，如果响应的 `statusCode` 为 `200` 则认为新的节点启动成功，整个部署才会成功；否则会收到 **应用启动检测失败** 类型的错误信息，导致部署失败。
 
 {% block ping %}{% endblock %}
 
@@ -56,6 +56,9 @@
 
 **提示**：如果在客户端想调用云引擎的预备环境，各个 SDK 都有类似于 `setProduction` 的方法，比如 [JavaScript SDK &middot; AV.setProduction(production)](/api-docs/javascript/symbols/AV.html#.setProduction)，其中 `production` 设置为 `0` 则该 SDK 将请求预备环境；设置为 `1` 将请求生产环境，默认为 `1`。
 
+### 运行环境定制
+
+{% block custom_runtime %}{% endblock %}
 
 ## 存储数据
 
@@ -67,84 +70,27 @@
 
 使用命令行工具可以非常方便地部署、发布应用，查看应用状态，查看日志，甚至支持多应用部署。具体使用请参考 [命令行工具指南](leanengine_cli.html)。
 
-除此之外，还可以使用 git 仓库部署。你需要将项目提交到一个 git 仓库，我们并不提供源码的版本管理功能，而是借助于 git 这个优秀的分布式版本管理工具。我们推荐你使用 [CSDN Code 平台](https://code.csdn.net/)、[Github](https://github.com/) 或者 [BitBucket](https://bitbucket.org/) 这样第三方的源码托管网站，也可以使用你自己搭建的 git 仓库（比如 [gitlab.org](http://gitlab.org/)）。
+### 使用 Git 部署
 
-### 使用 CSDN Code 托管源码
+除此之外，还可以使用 git 仓库部署。你需要将项目提交到一个 git 仓库，我们并不提供源码的版本管理功能，而是借助于 git 这个优秀的分布式版本管理工具。我们推荐你使用 [GitHub](https://github.com/)、[Coding](https://coding.net/) 或者 [OSChina](http://git.oschina.net/) 这样第三方的源码托管网站，也可以使用你自己搭建的 git 仓库（比如 [Gitlab](http://gitlab.org/)）。
 
-CSDN Code 是国内非常优秀的源码托管平台，你可以使用这个平台提供公有仓库和有限的私有仓库完成对代码的管理功能。以下是该平台与 LeanCloud 云引擎结合的一个例子。
-
-首先在 CSDN Code 上创建一个项目：
-
-![image](images/csdn_code1.png)
-
-**提示**：在已经有项目代码的情况下，一般不推荐 **使用 README 文件初始化项目**。
-
-接下来按照给出的提示，将源代码 push 到这个代码仓中：
+你需要先在这些平台上创建一个项目（如果已有代码，请不需要选择「Initialize this repository with a README」），在网站的个人设置中填写本地机器的 SSH 公钥（以 GitHub 为例，在 Settings => SSH and GPG keys 中点击 New SSH key），然后在项目目录执行：
 
 ```sh
-cd ${PROJECT_DIR}
 git init
-git add *
-git commit -m "first commit"
-git remote add origin git@code.csdn.net:${yourname}/test.git
+git add .
+git commit -m 'first commit'
+git remote add origin git@github.com:leancloud/node-js-getting-started.git
 git push -u origin master
 ```
 
-我们已经将源码成功推送到 CSDN Code 平台，接下来到 LeanCloud 云引擎的管理界面填写下你的 git 地址（请注意，一定要填写以 `git@` 开头的地址，我们暂不支持 https 协议 clone 源码）并点击 save 按钮保存：
+然后到云引擎的设置界面填写你的 Git 仓库地址，如果是公开仓库建议填写 https 地址，例如 `https://github.com/leancloud/node-js-getting-started.git`。
 
-![image](images/csdn_code2.png)
+如果是私有仓库需要填写 ssh 地址 `git@github.com:leancloud/node-js-getting-started.git`，还需要你将云引擎分配给你的公钥填写到第三方托管平台的 Deploy keys 中，以 GitHub 为例，在项目的 Settings => Deploy keys 中点击 Add deploy key。
 
-添加 deploy key 到你的 CSDN Code 平台项目上（deploy key 是我们云引擎机器的 ssh public key）保存到 **项目设置** / **项目公钥** 中，创建新的一项 avoscloud：
+设置好之后，今后需要部署代码时就可以在云引擎的部署界面直接点击「部署」了，默认会部署 master 分支的代码，你也可以在部署时填写分支、标签或具体的 Commit。
 
-![image](images/csdn_code3.png)
-
-下一步，部署源码到预备环境，进入 [云引擎 / Git 部署](/cloud.html?appid={{appid}}#/deploy) 菜单，点击「部署到开发环境」的部署按钮：
-
-![image](images/cloud_code_5.png)
-
-部署成功后，可以看到开发环境版本号从 undeploy 变成了当前提交的源码版本号。
-
-
-### 使用 GitHub 托管源码
-
-使用 BitBucket 与此类似，不再赘述。
-
-[Github](https://github.com) 是一个非常优秀的源码托管平台，你可以使用它的免费账号，那将无法创建私有仓库（bucket 可以创建私有仓库），也可以付费成为高级用户，可以创建私有仓库。
-
-首先在 Github上创建一个项目，比如就叫 `test`：
-
-![image](images/github1.png)
-
-![image](images/github2.png)
-
-接下来按照 Github 给出的提示，我们将源码 push 到这个代码仓库：
-
-```sh
-cd ${PROJECT_DIR}
-git init
-git add *
-git commit -m "first commit"
-git remote add origin git@github.com:${yourname}/test.git
-git push -u origin master
-```
-
-到这一步我们已经将源码成功 push 到 Github，接下来到云引擎的管理界面填写下你的 git 地址（请注意，一定要填写以 `git@` 开头的地址，我们暂不支持 https 协议 clone 源码）并点击 save 按钮保存：
-
-![image](images/cloud_code_4.png)
-
-并添加 deploy key 到你的 github 项目（deploy key 是我们云引擎机器的 ssh public key），如果你是私有项目，需要设置 deploy key，
-
-拷贝 **设置** 菜单里的 **Deploy key** 保存到 github setting 里的 deploy key，创建新的一项 avoscloud：
-
-![image](images/cloud_code_github_deploy_key.png)
-
-下一步，部署源码到预备环境，进入 **云引擎** / **Git 部署** 菜单，点击 **部署到开发环境** 的部署按钮：
-
-![image](images/cloud_code_5.png)
-
-部署成功后，可以看到开发环境版本号从 undeploy 变成了当前提交的源码版本号。
-
-### Gitlab 无法部署问题
+### Gitlab 常见问题
 
 很多用户自己使用 [Gitlab](http://gitlab.org/)搭建了自己的源码仓库，有朋友会遇到无法部署到 LeanCloud 的问题，即使设置了 Deploy Key，却仍然要求输入密码。
 
@@ -169,7 +115,18 @@ App dxzag3zdjuxbbfufuy58x1mvjq93udpblx7qoq0g27z51cx3's cloud code deploy key
 ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA5EZmrZZjbKb07yipeSkL+Hm+9mZAqyMfPu6BTAib+RVy57jAP/lZXuosyPwtLolTwdyCXjuaDw9zNwHdweHfqOX0TlTQQSDBwsHL+ead/p6zBjn7VBL0YytyYIQDXbLUM5d1f+wUYwB+Cav6nM9PPdBckT9Nc1slVQ9ITBAqKZhNegUYehVRqxa+CtH7XjN7w7/UZ3oYAvqx3t6si5TuZObWoH/poRYJJ+GxTZFBY+BXaREWmFLbGW4O1jGW9olIZJ5/l9GkTgl7BCUWJE7kLK5m7+DYnkBrOiqMsyj+ChAm+o3gJZWr++AFZj/pToS6Vdwg1SD0FFjUTHPaxkUlNw==
 ```
 
+## 设置域名
 
+首先，你需要到 [云引擎 > 设置](/cloud.html?appid={{appid}}#/conf) 页面找到 **Web 主机域名**，在这里填写你的域名：
+
+![image](images/cloud_code_web_setting.png)
+
+上面将应用的二级域名设置为 **myapp**，设置之后，你应该可以马上访问：
+
+- http://myapp.leanapp.cn
+- http://myapp.avosapps.us
+
+可能因为 DNS 生效延迟暂时不可访问，请耐心等待或者尝试刷新 DNS 缓存，如果还没有部署，你看到的应该是一个 404 页面。
 
 ## Web 组件
 
@@ -230,18 +187,78 @@ ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA5EZmrZZjbKb07yipeSkL+Hm+9mZAqyMfPu6BTAib+RVy
 
 部署并发布到生产环境之后，访问你的 {{productName}} 网站二级域名都会强制通过 HTTPS 访问。
 
-## 设置域名
+## 预备环境和生产环境
 
-首先，你需要到 [云引擎 > 设置](/cloud.html?appid={{appid}}#/conf) 页面找到 **Web 主机域名**，在这里填写你的域名：
+对于免费版应用，云引擎只有一个「生产环境」，对应的域名是 `{{var_app_domain}}.leanapp.cn`。
 
-![image](images/cloud_code_web_setting.png)
+专业版应用会有一个额外的「预备环境」，对应域名 `stg-{{var_app_domain}}.leanapp.cn`，两个环境所访问的都是同样的数据，你可以用预备环境测试你的云引擎代码，每次部署先部署到预备环境，测试通过后再发布到生产环境；如果你希望有一个独立数据源的测试环境，建议单独创建一个应用。
 
-上面将应用的二级域名设置为 **myapp**，设置之后，你应该可以马上访问：
+关于免费版和专业版的更多差别，请参考 [云引擎运行方案](leanengine_plan.html)。
 
-- http://myapp.leanapp.cn
-- http://myapp.avosapps.us
+有些时候你可能需要知道当前云引擎运行在什么环境（开发环境、预备环境或生产环境），从而做不同的处理：
 
-可能因为 DNS 生效延迟暂时不可访问，请耐心等待或者尝试刷新 DNS 缓存，如果还没有部署，你看到的应该是一个 404 页面。
+{% block get_env %}{% endblock %}
+
+你应该注意到了，我们在请求云引擎的时候，通过 REST API 的特殊的 HTTP 头 `X-LC-Prod`，来区分调用的环境。
+
+* 0 表示调用预备环境
+* 1 表示调用生产环境
+
+具体到 SDK 内的调用，请看各个平台的 SDK 指南。
+
+有时请求云引擎会遇到 `No Application Configured` 的错误，通常是因为对应的环境没有部署代码。例如免费版应用没有预备环境，或专业版应用尚未发布代码到生产环境。
+
+## 日志
+
+[云引擎 / 日志](/cloud.html?appid={{appid}}#/log)，可以查看云引擎的部署和运行日志，还可以通过日志级别进行筛选。
+
+应用的日志可以直接输出到「标准输出」或者「标准错误」，这些信息会分别对应日志的 `info` 和 `error` 级别，比如下列代码会在 info 级别记录参数信息：
+
+{% block loggerExample %}{% endblock %}
+
+**注意**：日志单行最大 4096 个字符，多余部分会被丢弃；日志输出频率大于 600 条/分钟，多余的部分会被丢弃。
+
+## 时区问题
+
+因为某些原因，云引擎 2.0 默认使用的是 UTC 时间，这给很多开发者带来了困惑，所以我们着重讨论下时区问题。
+
+比如有这样一个时间：`2015-05-05T06:15:22.024Z` (ISO 8601 表示法)，最后末尾的 `Z` 表示该时间是 UTC 时间。
+
+上面的时间等价于：`2015-05-05T14:15:22.024+0800`，注意此时末尾是 `+0800` 表示该时间是东八区时间。这两个时间的「小时」部分相差了 8 小时。
+
+### 时区问题产生的原因
+
+很多开发者在时间处理上会忽略「时区」标志，导致最后总是莫名其妙的出现 8 小时的偏差。
+
+【场景一】某开发者开发的应用使用云引擎的主机托管功能做了一个网站，其中有时间格式的表单提交。某用户使用浏览器访问该网站，提交表单，时间格式为：`2015-05-05 14:15:22.024`，注意该时间没有「时区」标志。因为这个时间是浏览器生成的，而该用户浏览器上的时间通常是东八区时间，所以该业务数据希望表达的时间是「东八区的 14 点」。
+
+该时间 `2015-05-05 14:15:22.024` 提交到服务器，被转换为 Date 类型（JavaScript 代码：`new Date('2015-05-05 14:15:22.024')`）。因为云引擎 2.0 使用的是 UTC 时间，所以该时间会被处理为 `2015-05-05T14:15:22.024Z`，即「UTC 时间的 14 点」。导致最后获得的时间和期望时间相差了 8 小时。
+
+解决上面的办法很简单：时间格式带上时区标志。即浏览器上传时间时使用 `2015-05-05T14:15:22.024+0800`，这样不管服务端默认使用什么时区，带有时区的时间格式转换的 Date 都不会有歧义。
+
+【场景二】从数据库获取某记录的 `createdAt` 属性，假设值为：`2015-04-09T03:35:09.678Z`。因为云引擎默认时区是 UTC，所以一些时间函数的返回结果如下：
+
+函数|结果
+---|---
+`toISOString`|2015-04-09T03:35:09.678Z
+`toLocaleString`|Thu Apr 09 2015 03:35:09 GMT+0000 (UTC)
+`toUTCString`|Thu, 09 Apr 2015 03:35:09 GMT
+`toString`|Thu Apr 09 2015 03:35:09 GMT+0000 (UTC)
+`getHours`|3，如果将 getHours 的结果返回给浏览器，或者作为业务数据使用，则会出现 8 小时的偏差。
+
+如果需要获取小时数据，解决办法是使用第三方的组件，比如 [moment-timezone](http://momentjs.com/timezone/)，通过下面的方式可以获得东八区的小时时间：
+
+```javascript
+var time = moment(obj.createdAt).tz('Asia/Shanghai');
+console.log('toString', time.toString());
+console.log('getHours', time.hours());
+```
+
+### 云引擎 2.0 和云引擎时区的差异
+
+为了方便大家的使用，更加符合通常的习惯，云引擎运行时环境（无沙箱的 Node.js 环境和 Python 环境）都是使用**东八区**作为默认时区。当然，我们仍然建议程序的时间字符串带有时区标志。
+
+{% block introduceCloudCodeV2 %}{% endblock %}
 
 ## 绑定独立域名
 
@@ -250,7 +267,7 @@ ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA5EZmrZZjbKb07yipeSkL+Hm+9mZAqyMfPu6BTAib+RVy
 ### 主域名
 
 仅使用云引擎托管静态文件、未使用其他 LeanCloud 服务的用户，需要自行办理独立域名与应用绑定的相关手续。
-{{productName}} 
+
 **请注意，根据政策法规要求，在完成绑定独立域名前，请不要将独立域名解析到云引擎**。
 
 其他用户如果需要为应用绑定一个独立域名，可以使用账户注册邮箱将下列信息发送至 <support@leancloud.cn>，或者从控制台菜单中选择 [帮助 / 技术支持](https://ticket.leancloud.cn/)，通过工单来提出申请：
@@ -397,91 +414,3 @@ WAP<br/>
 由我们和备案接入商来完成。备案完成后，我们再执行绑定操作。
 
 以上任何一个步骤有疑问都可以直接发邮件给 support@leancloud.rocks 进行询问，我们会有专人负责跟进和回答相关问题。
-
-## 运行环境定制
-
-{% block custom_runtime %}{% endblock %}
-
-## 预备环境和生产环境
-
-云引擎区分「预备环境」和「生产环境」， 它们拥有不同的域名:
-
-* 预备环境：`stg-{{var_app_domain}}.leanapp.cn`
-* 生产环境：`{{var_app_domain}}.leanapp.cn`
-
-但是两个环境使用相同的数据源。代码在预备环境测试通过后，再部署到生产环境是更安全的做法。
-
-**提示**：[免费版](leanengine_plan.html#免费版) 没有预备环境。
-
-**提示**: 如果希望能有一个独立数据源的测试环境，建议单独创建一个应用。
-
-有些时候你可能需要知道当前云引擎运行在什么环境（开发环境、预备环境或生产环境），从而做不同的处理：
-
-{% block get_env %}{% endblock %}
-
-你应该注意到了，我们在请求云引擎的时候，通过 REST API 的特殊的 HTTP 头 `X-LC-Prod`，来区分调用的环境。
-
-* 0 表示调用预备环境
-* 1 表示调用生产环境
-
-具体到 SDK 内的调用，请看各个平台的 SDK 指南。
-
-有些时候请求云引擎时会提示 production 还没有部署：
-
-```json
-{"code":1,"error":"The cloud code isn't deployed for prod 1."}
-```
-
-这个错误通常是只是部署了预备环境而没有部署生产环境导致的。
-
-## 时区问题
-
-因为某些原因，云引擎 2.0 默认使用的是 UTC 时间，这给很多开发者带来了困惑，所以我们着重讨论下时区问题。
-
-比如有这样一个时间：`2015-05-05T06:15:22.024Z` (ISO 8601 表示法)，最后末尾的 `Z` 表示该时间是 UTC 时间。
-
-上面的时间等价于：`2015-05-05T14:15:22.024+0800`，注意此时末尾是 `+0800` 表示该时间是东八区时间。这两个时间的「小时」部分相差了 8 小时。
-
-### 时区问题产生的原因
-
-很多开发者在时间处理上会忽略「时区」标志，导致最后总是莫名其妙的出现 8 小时的偏差。
-
-【场景一】某开发者开发的应用使用云引擎的主机托管功能做了一个网站，其中有时间格式的表单提交。某用户使用浏览器访问该网站，提交表单，时间格式为：`2015-05-05 14:15:22.024`，注意该时间没有「时区」标志。因为这个时间是浏览器生成的，而该用户浏览器上的时间通常是东八区时间，所以该业务数据希望表达的时间是「东八区的 14 点」。
-
-该时间 `2015-05-05 14:15:22.024` 提交到服务器，被转换为 Date 类型（JavaScript 代码：`new Date('2015-05-05 14:15:22.024')`）。因为云引擎 2.0 使用的是 UTC 时间，所以该时间会被处理为 `2015-05-05T14:15:22.024Z`，即「UTC 时间的 14 点」。导致最后获得的时间和期望时间相差了 8 小时。
-
-解决上面的办法很简单：时间格式带上时区标志。即浏览器上传时间时使用 `2015-05-05T14:15:22.024+0800`，这样不管服务端默认使用什么时区，带有时区的时间格式转换的 Date 都不会有歧义。
-
-【场景二】从数据库获取某记录的 `createdAt` 属性，假设值为：`2015-04-09T03:35:09.678Z`。因为云引擎默认时区是 UTC，所以一些时间函数的返回结果如下：
-
-函数|结果
----|---
-`toISOString`|2015-04-09T03:35:09.678Z
-`toLocaleString`|Thu Apr 09 2015 03:35:09 GMT+0000 (UTC)
-`toUTCString`|Thu, 09 Apr 2015 03:35:09 GMT
-`toString`|Thu Apr 09 2015 03:35:09 GMT+0000 (UTC)
-`getHours`|3，如果将 getHours 的结果返回给浏览器，或者作为业务数据使用，则会出现 8 小时的偏差。
-
-如果需要获取小时数据，解决办法是使用第三方的组件，比如 [moment-timezone](http://momentjs.com/timezone/)，通过下面的方式可以获得东八区的小时时间：
-
-```javascript
-var time = moment(obj.createdAt).tz('Asia/Shanghai');
-console.log('toString', time.toString());
-console.log('getHours', time.hours());
-```
-
-### 云引擎 2.0 和云引擎时区的差异
-
-为了方便大家的使用，更加符合通常的习惯，云引擎运行时环境（无沙箱的 Node.js 环境和 Python 环境）都是使用**东八区**作为默认时区。当然，我们仍然建议程序的时间字符串带有时区标志。
-
-{% block introduceCloudCodeV2 %}{% endblock %}
-
-## 日志
-
-[云引擎 / 日志](/cloud.html?appid={{appid}}#/log)，可以查看云引擎的部署和运行日志，还可以通过日志级别进行筛选。
-
-应用的日志可以直接输出到「标准输出」或者「标准错误」，这些信息会分别对应日志的 `info` 和 `error` 级别，比如下列代码会在 info 级别记录参数信息：
-
-{% block loggerExample %}{% endblock %}
-
-**注意**：日志单行最大 4096 个字符，多余部分会被丢弃；日志输出频率大于 600 条/分钟，多余的部分会被丢弃。


### PR DESCRIPTION
* 更新有关「免费版没有预备环境」的描述
* 调整段落顺序，「绑定独立域名」移到最后，「修改 Node.js」版本前移，「设置域名」前移到「部署」之后。
* 修正 Markdown 的格式（表示粗体的星号前后需要有空格）
* `app.use(AV.Cloud)` 改 `app.use(AV.express())`、修改 JS SDK 的初始化方式（Node SDK 1.x）
* 按照 Node SDK 1.x 的情况更新「处理用户登录和登出」小节
* 「健康检查」一节补充对 `/1.1/_ops/functions/metadatas` 的介绍
* `LC_` 开头的环境变量改 `LEANCLOUD_`
* 移除 `AV.Cloud.httpRequest` 的介绍，改成一个 request 的示例
* 「不建议使用 MemoryStore」的描述移到「自定义 session」小节
* 删除「Git 部署」一节中的截图，不再详细介绍 CSDN 和 GitHub 的界面，改推荐 Coding 和 OSChina 这两个国内托管，建议对于公开项目使用 https 链接。