### PR TITLE
[云函数开发指南 · Node.js] 细节修改

### DIFF
--- a/templates/include/header.html
+++ b/templates/include/header.html
@@ -190,8 +190,6 @@
           <li><a href="leanengine_examples.html">云引擎项目示例</a></li>
           <li><a href="leanengine_cli.html">云引擎命令行工具</a></li>
           <li><a href="acl_guide_leanengine.html">在云引擎中管理 ACL</a></li>
-          <li><a href="leanengine_guide-cloudcode.html">旧版云引擎环境</a></li>
-          <li><a href="leanengine_upgrade_3.html">云引擎 2.0 升级 3.0 指南</a></li>
           <li><a href="leanengine_faq.html">FAQ</a></li>
           <li><a href="leancache_guide.html">LeanCache 使用指南</a></li>
           </ul>

--- a/views/leanengine_cloudfunction_guide-node.md
+++ b/views/leanengine_cloudfunction_guide-node.md
@@ -43,26 +43,43 @@ AV.Cloud.define('averageStars', function(request, response) {
 {% endblock %}
 
 {% block cloudFuncParams %}
-有两个参数会被传入到云函数：
+Request 和 Response 会作为两个参数传入到云函数中：
 
-* **request**：包装了请求信息的请求对象，下列这些字段将被设置到 request 对象内：
-  * **params**：客户端发送的参数对象
-  * **user**：`AV.User` 对象，发起调用的用户，如果没有登录，则不会设置此对象。如果通过 REST API 调用时模拟用户登录，需要增加一个头信息 `X-AVOSCloud-Session-Token: <sessionToken>`，该 `sessionToken` 在用户登录或注册时服务端会返回。
-* **response**：应答对象，包含两个函数：
-  * **success**：这个函数可以接收一个额外的参数，表示返回给客户端的结果数据。这个参数对象可以是任意的 JSON 对象或数组，并且可以包含 `AV.Object` 对象。
-  * **error**：如果这个方法被调用，则表示发生了一个错误。它也接收一个额外的参数来传递给客户端，提供有意义的错误信息。
+`Request` 上的属性包括：
+
+* `params: object`：客户端发送的参数对象，当使用 `rpc` 调用时，也可能是 `AV.Object`。
+* `currentUser?: AV.User`：客户端所关联的用户（根据客户端发送的 `LC-Session` 头）。
+* `meta: object`：有关客户端的更多信息，目前只有一个 `remoteAddress` 属性表示客户端的 IP。
+* `sessionToken?: string`：客户端发来的 sessionToken（`X-LC-Session` 头）。
+
+`Response` 上的属性包括：
+
+* `success: function(result?)`：向客户端发送结果，可以是包括 AV.Object 在内的各种数据类型或数组，客户端解析方式见各 SDK 文档。
+* `error: function(err?: string)`：向客户端返回一个错误，目前仅支持字符串，`Error` 等类型也会被转换成字符串。
 {% endblock %}
 
 {% block runFuncExample %}
-
-```javascript
-AV.Cloud.run('averageStars', {movie: "夏洛特烦恼"}, {
-  success: function(data){
-    //调用成功，得到成功的应答data
+```js
+var paramsJson = {
+  movie: "夏洛特烦恼"
+};
+AV.Cloud.run('averageStars', paramsJson, {
+  success: function(data) {
+    // 调用成功，得到成功的应答data
   },
-  error: function(err){
-    //处理调用失败
+  error: function(err) {
+    // 处理调用失败
   }
+});
+```
+
+云引擎中默认会直接进行一次本地的函数调用，而不是像客户端一样发起一个 HTTP 请求。如果你希望发起 HTTP 请求来调用云函数，可以传入一个 `remote: true` 的选项（与 success 和 error 回调同级），当你在云引擎之外运行 Node SDK 时这个选项非常有用：
+
+```js
+AV.Cloud.run('averageStars', paramsJson, {
+  remote: true,
+  success: function(data) {},
+  error: function(err) {}
 });
 ```
 {% endblock %}
@@ -111,14 +128,14 @@ AV.Cloud.afterSave('Comment', function(request) {
 AV.Cloud.afterSave('_User', function(request) {
   console.log(request.object);
   request.object.set('from','LeanCloud');
-  request.object.save(null,{success:function(user)
-    {
+  request.object.save(null, {
+    success:function(user)  {
       console.log('ok!');
-    },error:function(user,error)
-    {
-      console.log('error',error);
+    },
+    error:function(user, error) {
+      console.log('error', error);
     }
-    });
+  });
 });
 ```
 {% endblock %}
@@ -141,17 +158,14 @@ AV.Cloud.beforeUpdate('Review', function(request, response) {
 });
 ```
 
-请注意：
-
-* 需要将 {{leanengine_middleware}} 中间件升级至 0.2.0 版本以上才能使用这个功能。
-* 不要修改 `request.object`，因为对它的改动并不会保存到数据库，但可以用 `response.error` 返回一个错误，拒绝这次修改。
+**注意：** 不要修改 `request.object`，因为对它的改动并不会保存到数据库，但可以用 `response.error` 返回一个错误，拒绝这次修改。
 {% endblock %}
 
 {% block afterUpdateExample %}
 
 ```javascript
 AV.Cloud.afterUpdate('Article', function(request) {
-   console.log('Updated article,the id is :' + request.object.id);
+  console.log('Updated article,the id is :' + request.object.id);
 });
 ```
 {% endblock %}
@@ -233,10 +247,10 @@ AV.Cloud.onLogin(function(request, response) {
 错误响应码允许自定义。云引擎方法最终的错误对象如果有 `code` 和 `message` 属性，则响应的 body 以这两个属性为准，否则 `code` 为 1， `message` 为错误对象的字符串形式。比如：
 
 ```
-AV.Cloud.define('errorCode', function(req, res) {
+AV.Cloud.define('errorCode', function(request, response) {
   AV.User.logIn('NoThisUser', 'lalala', {
     error: function(user, err) {
-      res.error(err);
+      response.error(err);
     }
   });
 });
@@ -245,8 +259,8 @@ AV.Cloud.define('errorCode', function(req, res) {
 
 {% block errorCodeExample2 %}
 ```
-AV.Cloud.define('customErrorCode', function(req, res) {
-  res.error({code: 123, message: 'custom error message'});
+AV.Cloud.define('customErrorCode', function(request, response) {
+  response.error({code: 123, message: 'custom error message'});
 });
 ```
 {% endblock %}
@@ -270,8 +284,8 @@ AV.Cloud.beforeSave('Review', function(request, response) {
 
 使用此功能需要注意：
 
-* 会替代你之前 git 或者命令行部署的项目。
-* 暂不提供主机托管功能。
+* 在定义的函数会覆盖你之前用 Git 或命令行部署的项目。
+* 目前只能在线编写云函数和 Hook，不支持托管静态网页、编写动态路由。
 
 在 [控制台 > 存储 > 云引擎 > 部署 > 在线编辑](/cloud.html?appid={{appid}}#/deploy/online) 标签页，可以：
 
@@ -283,16 +297,12 @@ AV.Cloud.beforeSave('Review', function(request, response) {
 **提示**：云函数编辑之后需要重新部署才能生效。
 {% endblock %}
 
-{% block timerLegacy %}
-**原来提供的 `AV.Cloud.setInterval` 和 `AV.Cloud.cronjob` 都已经废弃，这两个函数的功能变成和 `AV.Cloud.define` 一样，已经定义的任务会自动帮你做转换并启动。**
-{% endblock %}
-
 {% block timerExample %}
 
 ```javascript
-AV.Cloud.define('log_timer', function(req, res){
-    console.log('Log in timer.');
-    return res.success();
+AV.Cloud.define('log_timer', function(request, response){
+  console.log('Log in timer.');
+  return response.success();
 });
 ```
 {% endblock %}
@@ -300,14 +310,14 @@ AV.Cloud.define('log_timer', function(req, res){
 {% block timerExample2 %}
 
 ```javascript
-AV.Cloud.define('push_timer', function(req, res){
+AV.Cloud.define('push_timer', function(request, response){
   AV.Push.send({
-        channels: [ 'Public' ],
-        data: {
-            alert: 'Public message'
-        }
-    });
-   return res.success();
+    channels: ['Public'],
+    data: {
+      alert: 'Public message'
+    }
+  });
+  return response.success();
 });
 ```
 {% endblock %}
@@ -316,17 +326,16 @@ AV.Cloud.define('push_timer', function(req, res){
 
 ```javascript
 //参数依次为 AppId, AppKey, MasterKey
-AV.initialize('{{appid}}', '{{appkey}}', '{{masterkey}}');
+AV.init({
+  appId: '{{appid}}',
+  appKey: '{{appkey}}',
+  masterkey: '{{masterkey}}'
+})
 AV.Cloud.useMasterKey();
 ```
 {% endblock %}
 
-{% block masterKeyInitLegacy %}
-**注意：**云引擎 2.0 版本已经默认使用 master key 初始化 SDK，所以不需要额外初始化。
-{% endblock %}
-
 {% block loggerExample %}
-
 ```javascript
 AV.Cloud.define('Logger', function(request, response) {
   console.log(request.params);

--- a/views/leanengine_cloudfunction_guide.tmpl
+++ b/views/leanengine_cloudfunction_guide.tmpl
@@ -49,53 +49,52 @@ LeanCloud 各个语言版本的 SDK 都提供了调用云函数的接口。
 
 
 ```objc
-    // 在 iOS SDK 中，AVCloud 提供了一系列静态方法来实现客户端调用云函数
-    // 构建传递给服务端的参数字典
-     NSDictionary *dicParameters = [NSDictionary dictionaryWithObject:@"夏洛特烦恼" 
-                                                               forKey:@"movie"];
+// 在 iOS SDK 中，AVCloud 提供了一系列静态方法来实现客户端调用云函数
+// 构建传递给服务端的参数字典
+NSDictionary *dicParameters = [NSDictionary dictionaryWithObject:@"夏洛特烦恼"
+                                                          forKey:@"movie"];
 
-    // 调用指定名称的云函数 averageStars，并且传递参数
-    [AVCloud callFunctionInBackground:@"averageStars" 
-                       withParameters:dicParameters 
-                       block:^(id object, NSError *error) {
-                       if(error == nil){
-                         // 处理结果
-                       } else {
-                         // 处理报错
-                       }
-    }];
+// 调用指定名称的云函数 averageStars，并且传递参数
+[AVCloud callFunctionInBackground:@"averageStars"
+                   withParameters:dicParameters
+                   block:^(id object, NSError *error) {
+                   if(error == nil){
+                     // 处理结果
+                   } else {
+                     // 处理报错
+                   }
+}];
 ```
 ```java
-    // 在 Android SDK 中，AVCloud 提供了一系列的静态方法来实现客户端调用云函数
-    // 构建参数
-    Map<String, String> dicParameters = new HashMap<String, String>();
-    dicParameters.put("movie", "夏洛特烦恼");
+// 在 Android SDK 中，AVCloud 提供了一系列的静态方法来实现客户端调用云函数
+// 构建参数
+Map<String, String> dicParameters = new HashMap<String, String>();
+dicParameters.put("movie", "夏洛特烦恼");
 
-    // 调用云函数 averageStars
-    AVCloud.callFunctionInBackground("averageStars", dicParameters, new FunctionCallback() {
-        public void done(Object object, AVException e) {
-            if (e == null) {
-                // 处理返回结果
-            } else {
-                // 处理报错
-            }
+// 调用云函数 averageStars
+AVCloud.callFunctionInBackground("averageStars", dicParameters, new FunctionCallback() {
+    public void done(Object object, AVException e) {
+        if (e == null) {
+            // 处理返回结果
+        } else {
+            // 处理报错
         }
-    });
+    }
+});
 ```
 ```js
-  // 在 JavaScript 中 AV.Cloud 提供了一系列方法来调用云函数
-  var paramsJson = {
-    movie: "夏洛特烦恼"
-  };
-  AV.Cloud.run('averageStars', paramsJson, {
-    success: function(data) {
-      // 调用成功，得到成功的应答 data
-    },
-    error: function(err) {
-      // 处理调用失败
-    }
-  });
-
+// 在 JavaScript 中 AV.Cloud 提供了一系列方法来调用云函数
+var paramsJson = {
+  movie: "夏洛特烦恼"
+};
+AV.Cloud.run('averageStars', paramsJson, {
+  success: function(data) {
+    // 调用成功，得到成功的应答 data
+  },
+  error: function(err) {
+    // 处理调用失败
+  }
+});
 ```
 ### 通过 REST API 调用云函数
 [REST API 调用云函数](rest_api.html#云函数-1) 是 LeanCloud 云端提供的统一的访问云函数的接口，所有的客户端 SDK 也都是封装了这个接口从而实现对云函数的调用。
@@ -118,59 +117,44 @@ https://leancloud.cn/1.1/functions/averageStars
 
 在云引擎中可以使用 {{ runFuncName }} 调用 {{ defineFuncName }} 定义的云函数：
 
-```js
-  var paramsJson = {
-    movie: "夏洛特烦恼"
-  };
-  AV.Cloud.run('averageStars', paramsJson, {
-    success: function(data) {
-      // 调用成功，得到成功的应答data
-    },
-    error: function(err) {
-      // 处理调用失败
-    }
-  });
-```
-API 参数详解参见 {{ runFuncApiLink }}。
-
-**提示**：云引擎中调用云函数会变成一次本地调用，不会向其他 SDK 那样发起一次 HTTP 请求。
+{% block runFuncExample %}{% endblock %}
 
 ### RPC 调用云函数
 
 RPC 调用云函数是指：云引擎会在这种调用方式下自动为 Http Response Body 做序列化，而 SDK 调用之后拿回的返回结果就是一个完整的 `AVObject`。
 
 ```objc
-    NSDictionary *dicParameters = [NSDictionary dictionaryWithObject:@"夏洛特烦恼" 
-                                                              forKey:@"movie"];
+NSDictionary *dicParameters = [NSDictionary dictionaryWithObject:@"夏洛特烦恼"
+                                                          forKey:@"movie"];
 
-    [AVCloud rpcFunctionInBackground:@"averageStars" 
-                      withParameters:parameters 
-                      block:^(id object, NSError *error) {
-                      if(error == nil){
-                         // 处理结果
-                      } 
-                      else {
-                         // 处理报错
-                      }
-    }];
+[AVCloud rpcFunctionInBackground:@"averageStars"
+                  withParameters:parameters
+                  block:^(id object, NSError *error) {
+                  if(error == nil){
+                     // 处理结果
+                  }
+                  else {
+                     // 处理报错
+                  }
+}];
 ```
 ```java
-    AVObject movie = new AVObject("Movie");
-    movie.put("title", "夏洛特烦恼");
-    movie.save();
+AVObject movie = new AVObject("Movie");
+movie.put("title", "夏洛特烦恼");
+movie.save();
 
-    AVCloud.rpcFunctionInBackground("averageStars", movie,
-        new FunctionCallback<AVObject>() {
-          @Override
-          public void done(AVObject object, AVException e) {
-            Assert.assertNull(e);
-          }
-        });
+AVCloud.rpcFunctionInBackground("averageStars", movie,
+    new FunctionCallback<AVObject>() {
+      @Override
+      public void done(AVObject object, AVException e) {
+        Assert.assertNull(e);
+      }
+    });
 ```
 
 ### 切换云引擎环境
 
-云引擎区分「预备环境」和「生产环境」，使用 `AVCloud` 的 `setProductionMode` 方法可以切换环境：
+免费版云引擎应用只有「生产环境」，而专业版云引擎应用有一个额外的「生产环境」，使用 `AVCloud` 的 `setProductionMode` 方法可以在它们之间切换：
 
 ```objc
 [AVCloud setProductionMode:NO]; // 调用预备环境
@@ -196,7 +180,7 @@ AVCloud.setProductionMode(false); // 调用预备环境
 * 客户端收到 HTTP status code 为 503 响应，body 为 `The request timed out on the server.`。
 * 服务端会出现类似这样的日志：`LeanEngine function timeout, url=/1.1/functions/<cloudFunc>, timeout=15000`
 
-另外还需要注意：虽然 {{leanengine_middleware}} 已经响应，但此时云函数可能仍在执行，但执行完毕后的响应是无意义的。
+另外还需要注意：虽然 {{leanengine_middleware}} 已经响应，但此时云函数可能仍在执行，但执行完毕后的响应是无意义的（不会发给客户端，会在日志中打印一个 `Can't set headers after they are sent` 的异常）。
 
 #### 超时的处理方案
 
@@ -215,15 +199,16 @@ Hook 函数本质上是云函数，但它有固定的名称，定义之后会**�
 
 - 通过控制台进行 [数据导入](dashboard_guide.html#本地数据导入_LeanCloud) 不会触发以下任何 hook 函数。
 - 使用 Hook 函数需要 [防止死循环调用](#防止死循环调用)。
+_ `_Installation` 表暂不支持 Hook 函数。
 
 ### {{hook_before_save}}
-在将对象保存到云端数据表之前，可以对数据做一些清理或验证。例如，一条电影评论不能过长，否则界面上显示不开，需要将其截断至 140 个字符：
+在创建新对象之前，可以对数据做一些清理或验证。例如，一条电影评论不能过长，否则界面上显示不开，需要将其截断至 140 个字符：
 
 {% block beforeSaveExample %}{% endblock %}
 
 ### {{hook_after_save}}
 
-在数据保存后触发指定操作，比如当一条留言保存后再更新一下所属帖子的评论总数：
+在创建新对象后触发指定操作，比如当一条留言创建后再更新一下所属帖子的评论总数：
 
 {% block afterSaveExample %}{% endblock %}
 
@@ -236,7 +221,7 @@ Hook 函数本质上是云函数，但它有固定的名称，定义之后会**�
 ### {{hook_before_update}}
 
 {% block beforeUpdate %}
-在更新对象前执行操作，这时你可以知道哪些字段已被修改，还可以在特定情况下拒绝本次修改：
+在更新已存在的对象前执行操作，这时你可以知道哪些字段已被修改，还可以在特定情况下拒绝本次修改：
 
 {% block beforeUpdateExample %}{% endblock %}
 
@@ -245,7 +230,7 @@ Hook 函数本质上是云函数，但它有固定的名称，定义之后会**�
 
 ### {{hook_after_update}}
 
-在更新对象后执行特定的动作，比如每次修改文章后记录下日志：
+在更新已存在的对象后执行特定的动作，比如每次修改文章后记录下日志：
 
 {% block afterUpdateExample %}{% endblock %}
 
@@ -305,31 +290,31 @@ Hook 函数本质上是云函数，但它有固定的名称，定义之后会**�
 
 ```javascript
 AV.Cloud.afterUpdate('Post', function(request) {
-    // 直接修改并保存对象不会再次触发 afterUpdate Hook 函数
-    request.object.set('foo', 'bar');
-    request.object.save().then(function(obj) {
-      // 你的业务逻辑
-    });
+  // 直接修改并保存对象不会再次触发 afterUpdate Hook 函数
+  request.object.set('foo', 'bar');
+  request.object.save().then(function(obj) {
+    // 你的业务逻辑
+  }).catch(console.error);
 
-    // 如果有 fetch 操作，则需要在新获得的对象上调用相关的 disable 方法
-    // 来确保不会再次触发 Hook 函数
-    request.object.fetch().then(function(obj) {
-      obj.disableAfterHook();
-      obj.set('foo', 'bar');
-      return obj.save();
-    }).then(function(obj) {
-      // 你的业务逻辑
-    });
-
-    // 如果是其他方式构建对象，则需要在新构建的对象上调用相关的 disable 方法
-    // 来确保不会再次触发 Hook 函数
-    var obj = AV.Object.createWithoutData('Post', request.object.id);
+  // 如果有 fetch 操作，则需要在新获得的对象上调用相关的 disable 方法
+  // 来确保不会再次触发 Hook 函数
+  request.object.fetch().then(function(obj) {
     obj.disableAfterHook();
     obj.set('foo', 'bar');
-    obj.save().then(function(obj) {
-      // 你的业务逻辑
-    });
-  });
+    return obj.save();
+  }).then(function(obj) {
+    // 你的业务逻辑
+  }).catch(console.error);
+
+  // 如果是其他方式构建对象，则需要在新构建的对象上调用相关的 disable 方法
+  // 来确保不会再次触发 Hook 函数
+  var obj = AV.Object.createWithoutData('Post', request.object.id);
+  obj.disableAfterHook();
+  obj.set('foo', 'bar');
+  obj.save().then(function(obj) {
+    // 你的业务逻辑
+  }).catch(console.error);
+});
 ```
 
 **提示**：云引擎 Node.js 环境从 [0.3.0](https://github.com/leancloud/leanengine-node-sdk/blob/master/CHANGELOG.md#v030-20151231) 开始支持 `object.disableBeforeHook()` 和 `object.disableAfterHook()`。
@@ -354,8 +339,6 @@ Hook 函数的超时时间为 3 秒。如果 Hook 函数被其他的云函数调
 ## 定时任务
 
 定时任务可以按照设定，以一定间隔自动完成指定动作，比如半夜清理过期数据，每周一向所有用户发送推送消息等等。定时任务的最小时间单位是**秒**，正常情况下时间误差都可以控制在秒级别。
-
-{% block timerLegacy %}{% endblock %}
 
 定时任务是普通的云函数，也会遇到 [超时问题](#云函数超时)，具体请参考 [超时处理方案](#超时的处理方案)。
 
@@ -432,10 +415,8 @@ Cron 表达式的基本语法为：
 
 ## 权限说明
 
-云引擎可以有超级权限，使用 master key 调用所有 API，因此会忽略 ACL 和 Class Permission 限制。你只需要使用下列代码来初始化 SDK：
+云引擎可以有超级权限，使用 Master key 调用所有 API，因此会忽略 ACL 和 Class Permission 限制。你只需要使用下列代码来初始化 SDK（在线定义默认就有超级权限）：
 
 {% block masterKeyInit %}{% endblock %}
 
 如果在你的服务端环境里也想做到超级权限，也可以使用该方法初始化。
-
-{% block masterKeyInitLegacy %}{% endblock %}


### PR DESCRIPTION
* 撤下菜单中 [旧版云引擎环境] 和 [云引擎 2.0 升级 3.0 指南] 的链接
* 将 JavaScript 的代码调整为两个空格缩进，`req, res` 的变量命名调整为 `request, response`
* 细化 Request 和 Response 对象上的属性
* 补充 AV.Cloud.run 的 remote 参数
* 在实例代码的所有 Promise 加上 `.catch(console.error)`
* beforeSave/afterSave 的描述中强调是在创建对象时发生，beforeUpdate/afterUpdate 的描述中强调是在修改已有对象时发生
* 移除有关 cloudcode2 的内容（`AV.Cloud.setInterval` 和 `AV.Cloud.cronjob`）
* 免费版云引擎应用没有预备环境

@sdjcw 