### PR TITLE
fix(js-realtime): 将「离线消息推送」重命名为「离线消息内容通知」

### DIFF
--- a/md/realtime_guide-js.md
+++ b/md/realtime_guide-js.md
@@ -441,7 +441,7 @@ realtime.createIMClient('bob').then(function(bob) {
 
 ### 未读消息
 
-未读消息有两种处理方式，未读消息数量通知与离线消息内容通知。
+未读消息有两种处理方式，未读消息数量通知与离线消息通知。
 
 #### 未读消息数量通知
 
@@ -484,11 +484,11 @@ client.markAllAsRead([conversation]).then(function() {
 }).catch(console.error.bind(console));
 ```
 
-#### 离线消息内容通知
+#### 离线消息通知
 
-离线消息内容通知方式是指，当客户端上线时，服务器会主动将所有离线时收到的消息推送过来，每个对话最多推送 20 条最近的消息。当收到离线消息时，SDK 会在 Client 上派发 `messages` 事件，与在线时收到消息无异。
+离线消息通知方式是指，当客户端上线时，服务器会主动将所有离线时收到的消息推送过来，每个对话最多推送 20 条最近的消息。当收到离线消息时，SDK 会在 Client 上派发 `messages` 事件，与在线时收到消息无异。
 
-要使用离线消息内容通知方式，需要在初始化 Realtime 时设置参数 `pushOfflineMessages` 为 `true`：
+要使用离线消息通知方式，需要在初始化 Realtime 时设置参数 `pushOfflineMessages` 为 `true`：
 
 ```javascript
 var realtime = new AV.Realtime({

--- a/md/realtime_guide-js.md
+++ b/md/realtime_guide-js.md
@@ -439,15 +439,15 @@ realtime.createIMClient('bob').then(function(bob) {
 暂未实现
 
 
-### 离线消息
+### 未读消息
 
-离线消息有两种处理方式，未读消息通知与离线消息推送。
+未读消息有两种处理方式，未读消息数量通知与离线消息内容通知。
 
-#### 未读消息通知
+#### 未读消息数量通知
 
-未读消息通知是默认的离线消息处理方式：当客户端上线时，会收到其参与过的会话的离线消息数量的通知，然后由客户端负责主动拉取未读的消息并手动标记为已读。
+未读消息数量通知是默认的未读消息处理方式：当客户端上线时，会收到其参与过的会话的未读消息数量的通知，然后由客户端负责主动拉取未读的消息并手动标记为已读。
 
-当收到未读消息通知时，SDK 会在 Client 上派发 `unreadmessages` 事件。
+当收到未读消息数量通知时，SDK 会在 Client 上派发 `unreadmessages` 事件。
 
 ```javascript
 client.on('unreadmessages', function unreadMessagesEventHandler(payload, conversation) {
@@ -484,11 +484,11 @@ client.markAllAsRead([conversation]).then(function() {
 }).catch(console.error.bind(console));
 ```
 
-#### 离线消息推送
+#### 离线消息内容通知
 
-离线消息推送方式是指，当客户端上线时，服务器会主动将所有离线时收到的消息推送过来，每个对话最多推送 20 条最近的消息。当收到未读消息时，SDK 会在 Client 上派发 `messages` 事件，与在线时收到消息无异。
+离线消息内容通知方式是指，当客户端上线时，服务器会主动将所有离线时收到的消息推送过来，每个对话最多推送 20 条最近的消息。当收到离线消息时，SDK 会在 Client 上派发 `messages` 事件，与在线时收到消息无异。
 
-要使用离线消息推送方式，需要在初始化 Realtime 时设置参数 `pushOfflineMessages` 为 `true`：
+要使用离线消息内容通知方式，需要在初始化 Realtime 时设置参数 `pushOfflineMessages` 为 `true`：
 
 ```javascript
 var realtime = new AV.Realtime({


### PR DESCRIPTION
前者容易与 https://github.com/leancloud/docs/blob/dbaff34b2eddff42d2b431cd8bba68acd0e5d110/md/realtime_v2.md#离线推送通知 混淆

cc @nicecui 