### PR TITLE
Fix wrong deployment target for iOS SDK

### DIFF
--- a/md/start/ios_start.md
+++ b/md/start/ios_start.md
@@ -64,7 +64,7 @@ iOS 从 8.0 开始支持动态库，如果你的项目只支持 iOS 8 及以上�
 
 ##### 安装静态库
 
-<div class="callout callout-info">确保你正在使用最新版本的 Xcode（4.6+），并且面向 iOS 4.3 或者更高版本。我们推荐 Xcode 5 和 iOS 5 或以上系统。</div>
+<div class="callout callout-info">静态库支持 iOS 7.0 及以上系统。</div>
 
 首先，跟安装动态库一样，准备好待集成的模块。将它们放入同一个目录中：
 


### PR DESCRIPTION
修正 iOS SDK 快速入门中错误的 deployment target。这里特意把 Xcode 的说明删除了，因为跟 Xcode 版本没有关联。 @leancloud/docs-editor 