### PR TITLE
fix(docs): [存储] iOS 为链接增加 ID 符合 HTML5 标准

### DIFF
--- a/templates/pages/faq_list.html
+++ b/templates/pages/faq_list.html
@@ -57,7 +57,7 @@
         <li><a href="faq.html#Android_消息接收能不能自定义_Receiver_不弹出通知">Android 消息接收能不能自定义 Receiver 不弹出通知</a></li>
         <li><a href="faq.html#Android_应用进程被杀掉后无法收到推送消息">Android 应用进程被杀掉后无法收到推送消息</a></li>
         <li><a href="ios_push_cert.html#上传证书失败">为何无法上传 iOS 推送证书</a></li>
-        <li><a href="realtime_guide-ios.html#duplicate-offline-message-notification">为何在 iOS 上离线消息重复推送了两次？</a></li>
+        <li><a href="realtime_guide-ios.html#duplicate_message_notification">为何在 iOS 上离线消息重复推送了两次？</a></li>
       </ul>
     </div>
   </div>

--- a/views/realtime_guide-ios.md
+++ b/views/realtime_guide-ios.md
@@ -1805,7 +1805,7 @@ option.force = YES;
 {% block link_avquery_chache %} [存储指南 &middot; AVQuery 缓存查询](leanstorage_guide-ios.html#缓存查询) 一节。{% endblock %}
 
 {% block platform_specific_faq %}
-<a name="duplicate-offline-message-notification"></a>**为何离线消息重复推送了两次？**
+<a id="duplicate_message_notification" name="duplicate_message_notification"></a>**为何离线消息重复推送了两次？**
 
 大部分原因是这种情况造成的：成员 A 和成员 B 同在一个对话中。A 调用了 `openWithCallback` 登录实时通信，在没有调用 `closeWithCallback` 退出登录的情况下，B 使用同一个设备也调用了 `openWithCallback` 登录了实时通信。此时应用退出到后台，其他同在这个对话中的成员向这个对话发送了消息，服务器会给不在线的 A 和 B 发送消息推送，这个设备就会收到两条消息推送。解决方案是确保 B 登录时 A 已经调用 `closeWithCallback` 成功地退出了登录。
 {% endblock %}


### PR DESCRIPTION
Closes #1292

这个链接没有失效，一是在文档最后，屏幕滚动受限视觉上定位不明显，二是没有在地址栏中显示其 # 值。