### PR TITLE
添加 lean-cache-demos 的链接

### DIFF
--- a/md/leancache_guide.md
+++ b/md/leancache_guide.md
@@ -12,7 +12,7 @@ LeanCache 使用 [Redis](http://redis.io/) 来提供高性能、高可用的 Key
 
 <div style="max-width:620px"><img src="images/leancache_arch.png" class="img-responsive" alt=""></div>
 
-恰当使用 LeanCache 不仅可以极大地提高应用的服务性能，还能**降低成本**，因为某些高频率的查询不需要走存储服务（存储服务按调用次数收费）。
+恰当使用 LeanCache 不仅可以极大地提高应用的服务性能，还能**降低成本**，因为某些高频率的查询不需要走存储服务（存储服务按调用次数收费）。我们在 [LeanCache Node.js Demos](https://github.com/leancloud/lean-cache-demos) 这个仓库中包含了一些常见的使用场景的示例，可供大家参考。
 
 ## 主要特性
 
@@ -216,7 +216,7 @@ LeanCache 采取按天扣费，使用时间不足一天按一天收费，次日�
 
 - **多实例之间的数据共享**：云引擎支持多实例运行，自行维护的 HashTable 数据无法[跨实例共享](#多应用间共享使用)。
 - **数据持久化存储**：在程序重启或重新部署后数据不会丢失，Redis 会帮你完成数据持久化的工作。LeanCache 还会为你的 Redis 做热备，具有非常高的[可靠性](#可靠性)。
-- **原子操作和性能**：Redis 提供了常见的数据结构和大量原子操作，其文档中列出了每个操作符的时间复杂度，而自行实现的 HashTable 的性能则很大程度依赖于具体语言的实现（例如 V8 的 Array 实际上是通过 Hash Map 实现的）。
+- **原子操作和性能**：Redis 提供了常见的数据结构和大量原子操作，其文档中列出了每个操作符的时间复杂度，而自行实现的 HashTable 的性能则很大程度依赖于具体语言的实现。
 
 ### 报错：Redis connection gone from end event
 

--- a/md/leanengine_examples.md
+++ b/md/leanengine_examples.md
@@ -28,3 +28,14 @@
 
 如何开发 OAuth 授权验证回调服务器，请查看 [微博 OAuth 授权验证回调服务器开发指南](webhosting_oauth.html)。
 
+## LeanCache 常见场景示例
+
+[LeanCache Node.js Demos](https://github.com/leancloud/lean-cache-demos) 是 [LeanCache](https://leancloud.cn/docs/leancache_guide.html) 的示例项目，使用 Node.js 和 Express 实现，包含了一些典型的使用场景：
+
+* 关联数据缓存：缓存一些数据量少、查询频繁、不常修改、关联结构复杂的关联数据。
+* 图形验证码：利用图形验证码保护短信发送接口。
+* 排行榜缓存：维护一个用户游戏分数的排行榜，并在次日将榜单归档到云存储中。
+* 抢红包：管理员在后台生成一些随机金额的红包供用户获取，利用 LeanCache 应对瞬时的高并发场景。
+* 热点只读数据缓存：将几乎只读的配置（例如购物网站的商品分类信息）通过 Class Hook 缓存在 Redis。
+* 节点选举和锁：多个任务共同竞争一个资源（锁），确保同一时间只有一个任务能够在执行（持有这个锁）。
+* 任务队列：保证大量任务以指定的并发数量顺序地执行，以减少对其他服务的压力。


### PR DESCRIPTION
同时删去了 `（例如 V8 的 Array 实际上是通过 Hash Map 实现的）` 这句话，这本来是我回复在论坛上的，写在这里可能过于细节了，用户并不关心这个。