### PR TITLE
混合推送增加权限控制说明

### DIFF
--- a/md/push_guide.md
+++ b/md/push_guide.md
@@ -63,7 +63,7 @@ errors| | 本次推送过程中的错误信息。
 
 在部分 Android ROM 上，由于系统对后台进程控制较严，Android 推送的到达率会受到影响。为此我们专门设计了一套称为混合推送的高级推送机制，用以提高在这部分 Android ROM 上推送的到达率。
 
-目前 Android 混合推送功能处于免费试用阶段，请在 [控制台 / 设置 / 应用选项](/app.html?appid={{appid}}#/permission) 页面，“聊天、推送” 相关应用选项内，开启 Android 混合推送。
+目前 Android 混合推送功能处于免费试用阶段，如果希望试用该功能，请在 [控制台 / 设置 / 应用选项](/app.html?appid={{appid}}#/permission) 页面下，“聊天、推送” 一栏点选 “开启混合推送“ 选项。
 
 关于混合推送的接入方法和使用方式请阅读 [Android 混合推送使用文档](./android_push_guide.html#混合推送)。
 

--- a/md/push_guide.md
+++ b/md/push_guide.md
@@ -61,7 +61,9 @@ errors| | 本次推送过程中的错误信息。
 
 ## Android 混合推送
 
-在部分 Android ROM 上，由于系统对后台进程控制较严，Android 推送的到达率会受到影响。为此我们专门设计了一套称为混合推送的推送机制，用以提高在这部分 Android ROM 上推送的到达率。
+在部分 Android ROM 上，由于系统对后台进程控制较严，Android 推送的到达率会受到影响。为此我们专门设计了一套称为混合推送的高级推送机制，用以提高在这部分 Android ROM 上推送的到达率。
+
+目前 Android 混合推送功能处于免费试用阶段，请在 [控制台 / 设置 / 应用选项](/app.html?appid={{appid}}#/permission) 页面，“聊天、推送” 相关应用选项内，开启 Android 混合推送。
 
 关于混合推送的接入方法和使用方式请阅读 [Android 混合推送使用文档](./android_push_guide.html#混合推送)。
 


### PR DESCRIPTION
混合推送之后会属于收费功能，增加了一个选项做权限控制，需要用户点击一下才能开始试用混合推送功能。这里增加说明。