### PR TITLE
fix(docs): [nav] 去掉 iOS 测试分发链接

### DIFF
--- a/templates/include/header.html
+++ b/templates/include/header.html
@@ -34,7 +34,6 @@
               <li><a href="http://blog.leancloud.cn/">Blog</a></li>
               <li role="presentation" class="divider"></li>
               <li><a href="https://leancloud.cn/apionline/">在线 API 工具</a></li>
-              <li><a href="http://drop.avosapps.com/">iOS 测试包分发</a></li>
               <li><a href="http://leancloud.sexy" target="_blank">第三方库</a></li>
               <li role="presentation" class="divider"></li>
               <li><a href="/apps.html">LeanCloud App</a></li>


### PR DESCRIPTION
Closes #1431