### PR TITLE
[云引擎] 重构 Node.js 网站托管指南

### DIFF
--- a/views/leanengine_faq.md
+++ b/views/leanengine_faq.md
@@ -8,7 +8,7 @@
 
 云引擎 2.0 开始支持添加第三方模块（请参考 [云引擎指南 - 升级到 2.0](leanengine_guide-cloudcode.html#云引擎_2_0_版)），只需要像普通的 Node.js 项目那样，在项目根目录创建文件 `package.json`，下面是一个范例：
 
-``` 
+```
 {
   "name": "cloud-engine-test",
   "description": "Cloud Engine test project.",
@@ -25,7 +25,7 @@
 
 然后在项目根目录执行：
 
-``` 
+```
 npm install
 ```
 
@@ -33,7 +33,7 @@ npm install
 
 然后即可在代码中引入三方包：
 
-``` 
+```
 var async = require('async');
 ```
 
@@ -42,7 +42,7 @@ var async = require('async');
 ## Maximum call stack size exceeded 如何解决？
 
 如果你的应用时不时出现 `Maximum call stack size exceeded` 异常，可能是因为在 hook 中调用了 `AV.Object.extend`。有两种方法可以避免这种异常：
- 
+
 - 升级 leanengine 到 v1.2.2 或以上版本
 - 在 hook 外定义 Class（即定义在 `AV.Cloud.define` 方法之外），确保不会对一个 Class 执行多次 `AV.Object.extend`
 
@@ -122,4 +122,29 @@ AV.Cloud.define('querySomething', function(req, res) {
   }).catch(function(err){
     //返回错误给客户端
   });
+```
+
+## Gitlab 部署常见问题
+
+很多用户自己使用 [Gitlab](http://gitlab.org/)搭建了自己的源码仓库，有朋友会遇到无法部署到 LeanCloud 的问题，即使设置了 Deploy Key，却仍然要求输入密码。
+
+可能的原因和解决办法如下：
+
+* 确保你 gitlab 运行所在服务器的 /etc/shadow 文件里的 git（或者 gitlab）用户一行的 `!`修改为 `*`，原因参考 [Stackoverflow - SSH Key asks for password](http://stackoverflow.com/questions/15664561/ssh-key-asks-for-password)，并重启 SSH 服务：`sudo service ssh restart`。
+* 在拷贝 deploy key 时，确保没有多余的换行符号。
+* Gitlab 目前不支持有 comment 的 deploy key。早期 LeanCloud 用户生成的 deploy key 可能带 comment，这个 comment 是在 deploy key 的末尾 76 个字符长度的字符串，例如下面这个 deploy key：
+
+```
+ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA5EZmrZZjbKb07yipeSkL+Hm+9mZAqyMfPu6BTAib+RVy57jAP/lZXuosyPwtLolTwdyCXjuaDw9zNwHdweHfqOX0TlTQQSDBwsHL+ead/p6zBjn7VBL0YytyYIQDXbLUM5d1f+wUYwB+Cav6nM9PPdBckT9Nc1slVQ9ITBAqKZhNegUYehVRqxa+CtH7XjN7w7/UZ3oYAvqx3t6si5TuZObWoH/poRYJJ+GxTZFBY+BXaREWmFLbGW4O1jGW9olIZJ5/l9GkTgl7BCUWJE7kLK5m7+DYnkBrOiqMsyj+ChAm+o3gJZWr++AFZj/pToS6Vdwg1SD0FFjUTHPaxkUlNw== App dxzag3zdjuxbbfufuy58x1mvjq93udpblx7qoq0g27z51cx3's cloud code deploy key
+```
+其中最后 76 个字符：
+
+```
+App dxzag3zdjuxbbfufuy58x1mvjq93udpblx7qoq0g27z51cx3's cloud code deploy key
+```
+
+就是 comment，删除这段字符串后的 deploy key（如果没有这个字样的comment无需删除）保存到 gitlab 即可正常使用：
+
+```
+ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA5EZmrZZjbKb07yipeSkL+Hm+9mZAqyMfPu6BTAib+RVy57jAP/lZXuosyPwtLolTwdyCXjuaDw9zNwHdweHfqOX0TlTQQSDBwsHL+ead/p6zBjn7VBL0YytyYIQDXbLUM5d1f+wUYwB+Cav6nM9PPdBckT9Nc1slVQ9ITBAqKZhNegUYehVRqxa+CtH7XjN7w7/UZ3oYAvqx3t6si5TuZObWoH/poRYJJ+GxTZFBY+BXaREWmFLbGW4O1jGW9olIZJ5/l9GkTgl7BCUWJE7kLK5m7+DYnkBrOiqMsyj+ChAm+o3gJZWr++AFZj/pToS6Vdwg1SD0FFjUTHPaxkUlNw==
 ```

--- a/views/leanengine_webhosting_guide-java.md
+++ b/views/leanengine_webhosting_guide-java.md
@@ -6,6 +6,7 @@
 {% set leanengine_middleware = "[LeanEngine Java SDK](https://github.com/leancloud/leanengine-java-sdk)" %}
 
 {% block project_constraint %}
+你的项目需要遵循一定格式才会被云引擎识别并运行。
 
 {{fullName}} 项目必须有 `$PROJECT_DIR/pom.xml` 文件，该文件为整个项目的配置文件。
 
@@ -146,6 +147,8 @@ AVOSCloud.initialize(System.getenv("LEANCLOUD_APP_ID"), // 你的 app id
 {% endblock %}
 
 {% block custom_api_random_string %}
+{{productName}} 允许开发者自定义基于 HTTP（HTTPS） 的 API。
+例如，开发者如果想实现一个获取服务端时间的 API，可以在代码中如下做：
 
 新建一个类 TimeServlet 继承 HttpServlet :
 
@@ -164,6 +167,14 @@ public class TimeServlet extends HttpServlet {
 }
 
 ```
+
+然后打开浏览器，访问 <http://localhost:3000/time>，浏览器应该会返回如下类似的内容：
+
+```json
+{"currentTime":"2016-02-01T09:43:26.223Z"}
+```
+
+部署到云端后，你可以通过 `http://{{var_app_domain}}.leanapp.cn/time` 来访问该 API。你的 iOS 或者 Android 的程序就可以构建一个 HTTP 请求获取服务端时间了。当然还是建议使用各 SDK 内置的获取服务器时间的 API，这里的例子只是演示。
 {% endblock %}
 
 {% block code_get_client_ip_address %}
@@ -223,9 +234,6 @@ public class UploadServlet extends HttpServlet {
 {% endblock %}
 
 {% block cookie_session %}
-
-### 处理用户登录和登出
-
 云引擎提供了一个 `EngineSessionCookie` 组件，用 Cookie 来维护用户（`AVUser`）的登录状态，要使用这个组件可以在初始化时添加下列代码：
 
 ```java

--- a/views/leanengine_webhosting_guide-node.md
+++ b/views/leanengine_webhosting_guide-node.md
@@ -7,137 +7,290 @@
 {% set sdk_name = 'JavaScript' %}
 {% set leanengine_middleware = '[LeanEngine Node.js SDK](https://github.com/leancloud/leanengine-node-sdk)' %}
 
-
-{% block custom_api_random_string %}
-打开 `./app.js` ，添加如下代码：
-
-```js
-app.get('/time', function(req, res) {
-  res.send({ currentTime: new Date() });
-});
-```
-{% endblock %}
-
 {% block project_constraint %}
-{{fullName}} 项目必须有 `$PROJECT_DIR/server.js` 文件，该文件为整个项目的启动文件。
+<script>$(window).load(function() {$('.do-expand-all').click();})</script>
 
-**注意：** 项目中 **不能** 有 `$PROJECT_DIR/cloud/main.js` 文件，否则会被识别为 [2.0 版本](./leanengine_guide-cloudcode.html#项目约束) 的项目。
-{% endblock %}
+你的项目根目录项目 **必须** 有一个 `package.json` 文件，才会正确地被云引擎识别为 Node.js 项目。
 
-{% block project_start %}
-### 项目启动
+<div class="callout callout-info">因为一些历史遗留问题，请确保你的项目中 **没有** 名为 `cloud/main.js` 的文件。</div>
 
-如果 `$PROJECT_DIR/package.json` 文件有自定义的启动脚本：
+### package.json
 
-```
+Node.js 的 `package.json` 中可以指定 [很多选项](https://docs.npmjs.com/files/package.json)，它通常看起来是这样：
+
+```json
 {
-  ...
-  "scripts": {
-    ...
-    "start": "node server.js",
-    ...
-  },
-  ...
+    "name": "node-js-getting-started",
+    "scripts": {
+        "start": "node server.js"
+    },
+    "engine": {
+        "node": "4.x"
+    },
+    "dependencies": {
+        "express": "4.12.3",
+        "leanengine": "1.2.2"
+    }
 }
 ```
 
-则会使用 `npm start` 方式启动。这意味着可以使用 [npm scripts](https://docs.npmjs.com/misc/scripts) 来定制启动过程。
+其中云引擎会尊重的选项包括：
 
-**提示：** 有些遗留项目可能会将 `start` 脚本写成 `node ./app.js` 从而导致启动检测失败，所以将脚本改成 `node server.js` 或者你确认的启动方式即可。
+* `scripts.start` 启动项目时使用的命令；默认为 `node server.js`，如果你希望为 node 附加启动选项（如 `--es_staging`）或使用其他的文件作为入口点，可以修改该选项。
+* `scripts.prepublish` 会在项目部署最后运行一次；可以将构建命令（如 `gulp build`）写在这里。
+* `engines.node` 指定所需的 Node.js 版本；出于兼容性考虑默认版本仍为比较旧的 `0.12`，**因此建议大家自行指定一个更高的版本，建议使用 `4.x` 版本进行开发**，你也可以设置为 `*` 表示总是使用最新版本的 Node.js。
+* `dependencies` 项目所依赖的包；云引擎会在部署时用 `npm install --production` 为你安装这里列出的所有依赖。
+* `devDependencies` 项目开发时所依赖的包；云引擎目前 **不会** 安装这里的依赖。
 
-如果没有 `start` 脚本，则默认使用 `node server.js` 来启动，所以需要保证存在 `$PROJECT_DIR/server.js` 文件。 {% endblock %}
+建议你参考我们的 [项目模板](https://github.com/leancloud/node-js-getting-started/blob/master/package.json) 来编写自己的 `package.json`。
+{% endblock %}
 
-{% block ping %}
-{{leanengine_middleware}} 内置了该 URL 的处理，只需要将中间件添加到请求的处理链路中即可：
+{% block project_start %}
+{% endblock %}
 
-```
-app.use(AV.express());
-```
-
-如果未使用 {{leanengine_middleware}}，则需要自己实现该 URL 的处理，比如这样：
-
-```
-// 健康监测 router
-app.use('/__engine/1/ping', function(req, res) {
-  res.end(JSON.stringify({
-    "runtime": "nodejs-" + process.version,
-    "version": "custom"
-  }));
-});
-
-// 云函数列表
-app.get('/1.1/_ops/functions/metadatas', function(req, res) {
-  res.end(JSON.stringify([]));
-});
-```
+{% block custom_runtime %}
 {% endblock %}
 
 {% block supported_frameworks %}
+Node SDK 为 [express](http://expressjs.com/) 和 [koa](http://koajs.com/) 提供了集成支持，如果你使用这两个框架，只需通过下面的方式加载 Node SDK 提供的中间件即可。
 
-{{fullName}} 支持任意 [Node.js](https://nodejs.org) 的 Web 框架，你可以使用你最熟悉的框架进行开发，或者不使用任何框架，直接使用 Node.js 的 http 模块进行开发。但是请保证通过执行 `server.js` 能够启动你的项目，启动之后程序监听的端口为 `process.env.LEANCLOUD_APP_PORT`。
+你可以在你的项目根目录运行 `npm install leanengine@next --save` 来安装 Node SDK。
 
-#### Express
+### Express
 
 ```js
 var express = require('express');
 var AV = require('leanengine');
 
-var app = express();
+AV.init({
+  appId: process.env.LEANCLOUD_APP_ID || '{{appid}}',
+  appKey: process.env.LEANCLOUD_APP_KEY || '{{appkey}}',
+  masterKey: process.env.LEANCLOUD_APP_MASTER_KEY || '{{masterkey}}'
+});
 
+var app = express();
 app.use(AV.express());
 app.listen(process.env.LEANCLOUD_APP_PORT);
 ```
 
-#### Koa
+你可以使用 express 的路由定义功能来提供自定义的 HTTP API：
 
-使用 [Koa](http://koajs.com/) 时建议按照 [运行环境定制](#运行环境定制) 将 Node.js 的版本设置为 `4.x`。
+```js
+app.get('/', function(req, res) {
+  res.render('index', {title: 'Hello world'});
+});
+
+app.get('/time', function(req, res) {
+  res.json({
+    time: new Date()
+  });
+});
+
+app.get('/todos', function(req, res) {
+  new AV.Query('Todo').find().then(function(todos) {
+    res.json(todos);
+  }).catch(function(err) {
+    res.status(500).json({
+      error: err.message
+    });
+  });
+});
+
+```
+
+更多最佳实践请参考我们的 [项目模板](https://github.com/leancloud/node-js-getting-started) 和 [云引擎项目示例](leanengine_examples.html)。
+
+### Koa
 
 ```js
 var koa = require('koa');
 var AV = require('leanengine');
 
-var app = koa();
+AV.init({
+  appId: process.env.LEANCLOUD_APP_ID || '{{appid}}',
+  appKey: process.env.LEANCLOUD_APP_KEY || '{{appkey}}',
+  masterKey: process.env.LEANCLOUD_APP_MASTER_KEY || '{{masterkey}}'
+});
 
+var app = koa();
 app.use(AV.koa());
 app.listen(process.env.LEANCLOUD_APP_PORT);
 ```
-{% endblock %}
 
-{% block code_get_client_ip_address %}
+你可以使用 koa 来渲染页面、提供自定义的 HTTP API：
+
 ```js
-app.get('/', function(req, res) {
-  console.log(req.headers['x-real-ip']);// 打印 IP 地址
-  res.render('index', { currentTime: new Date() });
+app.use(function *(next) {
+  if (this.url === '/') {
+    // https://github.com/tj/co-views
+    yield coViews('views')('index', {title: 'Hello world'});
+  } else {
+    yield next;
+  }
 });
+
+app.use(function *(next) {
+  if (this.url === '/time') {
+    this.body = {
+      time: new Date()
+    };
+  } else {
+    yield next;
+  }
+});
+
+app.use(function *(next) {
+  if (this.url === '/todos') {
+    return new AV.Query('Todo').find().then(todos => {
+      this.body = todos;
+    });
+  } else {
+    yield next;
+  }
+});
+
+```
+
+使用 Koa 时建议按照前面 [package.json](#package.json) 一节将 Node.js 的版本设置为 `4.x` 以上。
+
+### 其他 Web 框架
+
+你也可以使用其他的 Web 框架进行开发，但你需要自行去实现 [健康监测](#健康监测) 中提到的逻辑。下面是一个使用 Node.js 内建的 [http](https://nodejs.org/api/http.html) 实现的最简示例，可供参考：
+
+```js
+require('http').createServer(function(req, res) {
+  if (req.url == '/') {
+    res.statusCode = 200;
+    res.end();
+  } else {
+    res.statusCode = 404;
+    res.end();
+  }  
+}).listen(process.env.LEANCLOUD_APP_PORT);
 ```
 {% endblock %}
 
 {% block use_leanstorage %}
-云引擎使用 {{leanengine_middleware}} 来代替 [JavaScript 存储 SDK](https://github.com/leancloud/javascript-sdk) 。前者包含了后者，并增加了云函数和 Hook 函数的支持，因此开发者可以直接使用 [LeanCloud 的存储服务](leanstorage_guide-js.html) 来存储自己的数据。
+云引擎中的 Node SDK 是对 [JavaScript 存储 SDK](https://github.com/leancloud/javascript-sdk) 的拓展，增加了服务器端需要的云函数和 Hook 相关支持，在云引擎中你需要用 `leanengine` 这个包来操作 [LeanCloud 的存储服务](leanstorage_guide-js.html) 中的数据，你可以在你的项目根目录运行 `npm install leanengine@next --save` 来安装 Node SDK。
 
-如果使用项目框架作为基础开发，{{leanengine_middleware}} 默认是配置好的，可以根据示例程序的方式直接使用。
-
-如果是自定义项目，则需要自己配置：
-
-* 配置依赖：在项目根目录下执行以下命令来增加 {{leanengine_middleware}} 的依赖：
-
-```
-$ npm install leanengine@next --save
-```
-
-* 初始化：在正式使用数据存储之前，你需要使用自己的应用 key 进行初始化中间件：
+Node SDK 的 [API 文档](https://github.com/leancloud/leanengine-node-sdk/blob/master/API.md) 和 [更新日志](https://github.com/leancloud/leanengine-node-sdk/releases) 都在 GitHub 上。
 
 ```js
 var AV = require('leanengine');
 
 AV.init({
-  appId: process.env.LEANCLOUD_APP_ID || '{{appid}}', // 你的 app id
-  appKey: process.env.LEANCLOUD_APP_KEY || '{{appkey}}', // 你的 app key
-  masterKey: process.env.LEANCLOUD_APP_MASTER_KEY || '{{masterkey}}' // 你的 master key
+  appId: process.env.LEANCLOUD_APP_ID || '{{appid}}',
+  appKey: process.env.LEANCLOUD_APP_KEY || '{{appkey}}',
+  masterKey: process.env.LEANCLOUD_APP_MASTER_KEY || '{{masterkey}}'
 });
 
-// 如果不希望使用 masterKey 权限，可以将下面一行删除
+// 你可以使用 useMasterKey 在云引擎中开启 masterKey 权限，将会跳过 ACL 和其他权限限制。
 AV.Cloud.useMasterKey();
+
+// 使用 JavaScript 的 API 查询云存储中的数据。
+new AV.Query('Todo').find().then(function(todos) {
+  console.log(todos);
+}).catch(function(err) {
+  console.log(err)
+});
+```
+
+Node SDK 有过两个大版本：
+
+* `0.x`：最初的版本，对 Node.js 4.x 及以上版本兼容不佳，建议用户参考 [升级到云引擎 Node.js SDK 1.0](leanengine-node-sdk-upgrade-1.html) 来更新
+* `1.x`：**推荐使用** 的版本，彻底废弃了全局的 currentUser，依赖的 JavaScript 也升级到了 1.x 分支，支持了 Koa 和 Node.js 4.x 及以上版本。
+
+## 本地运行和调试
+
+在你首次启动应用之前需要先安装依赖：
+
+```sh
+npm install
+```
+
+然后便可以在项目根目录，用我们的命令行工具来启动本地调试了：
+
+```sh
+lean up
+```
+
+更多有关命令行工具和本地调试的内容请看 [云引擎命令行工具使用详解](leanengine_cli.html)。
+
+{% endblock %}
+
+{% block get_env %}
+```javascript
+var NODE_ENV = process.env.NODE_ENV || 'development';
+if (NODE_ENV === 'development') {
+  // 当前环境为「开发环境」，是由命令行工具启动的
+} else if(NODE_ENV == 'production') {
+  // 当前环境为「生产环境」，是线上正式运行的环境
+} else {
+  // 当前环境为「预备环境」
+}
+```
+{% endblock %}
+
+{% block cookie_session %}
+云引擎提供了一个 `AV.Cloud.CookieSession` 中间件，用 Cookie 来维护用户（`AV.User`）的登录状态，要使用这个中间件可以在 `app.js` 中添加下列代码：
+
+```javascript
+app.use(AV.Cloud.CookieSession({ secret: 'my secret', maxAge: 3600000, fetchUser: true }));
+```
+
+Koa 需要添加一个 `framework: 'koa'` 的参数：
+
+```javascript
+app.use(AV.Cloud.CookieSession({ framework: 'koa', secret: 'my secret', maxAge: 3600000, fetchUser: true }));
+```
+
+你需要传入一个 secret 用于签名 Cookie（必须提供），这个中间件会将 `AV.User` 的登录状态信息记录到 Cookie 中，用户下次访问时自动检查用户是否已经登录，如果已经登录，可以通过 `req.currentUser` 获取当前登录用户。
+
+`AV.Cloud.CookieSession` 支持的选项包括：
+
+* **fetchUser**：**是否自动 fetch 当前登录的 AV.User 对象。默认为 false。**  
+  如果设置为 true，每个 HTTP 请求都将发起一次 LeanCloud API 调用来 fetch 用户对象。如果设置为 false，默认只可以访问 `req.currentUser` 的 `id`（`_User` 表记录的 ObjectId）和 `sessionToken` 属性，你可以在需要时再手动 fetch 整个用户。
+* **name**：Cookie 的名字，默认为 `avos.sess`。
+* **maxAge**：设置 Cookie 的过期时间。
+
+在 Node SDK 1.x 之后我们不再允许通过 `AV.User.current()` 获取登录用户的信息（详见 [升级到云引擎 Node.js SDK 1.0](leanengine-node-sdk-upgrade-1.html#废弃_currentUser)），而是需要你：
+
+* 在云引擎方法中，通过 `request.currentUser` 获取用户信息。
+* 在网站托管中，通过 `request.currentUser` 获取用户信息。
+* 在后续的方法调用显示传递 user 对象。
+
+你可以这样简单地实现一个具有登录功能的站点：
+
+```javascript
+// 处理登录请求（可能来自登录界面中的表单）
+app.post('/login', function(req, res) {
+  AV.User.logIn(req.body.username, req.body.password).then(function(user) {
+    res.saveCurrentUser(user); // 保存当前用户到 Cookie
+    res.redirect('/profile'); // 跳转到个人资料页面
+  }, function(error) {
+    //登录失败，跳转到登录页面
+    res.redirect('/login');
+  });
+})
+
+// 查看个人资料
+app.get('/profile', function(req, res) {
+  // 判断用户是否已经登录
+  if (req.currentUser) {
+    // 如果已经登录，发送当前登录用户信息。
+    res.send(req.currentUser);
+  } else {
+    // 没有登录，跳转到登录页面。
+    res.redirect('/login');
+  }
+});
+
+// 登出账号
+app.get('/logout', function(req, res) {
+  req.currentUser.logOut();
+  res.clearCurrentUser(); // 从 Cookie 中删除用户
+  res.redirect('/profile');
+});
 ```
 {% endblock %}
 
@@ -171,7 +324,15 @@ request({
   }
 });
 ```
+{% endblock %}
 
+{% block code_get_client_ip_address %}
+```js
+app.get('/', function(req, res) {
+  console.log(req.headers['x-real-ip']);// 打印 IP 地址
+  res.render('index', { currentTime: new Date() });
+});
+```
 {% endblock %}
 
 {% block upload_file_special_middleware %}
@@ -207,110 +368,35 @@ app.post('/upload', function(req, res){
 ```
 {% endblock %}
 
-{% block cookie_session %}
-### 处理用户登录和登出
-
-云引擎提供了一个 `AV.Cloud.CookieSession` 中间件，用 Cookie 来维护用户（`AV.User`）的登录状态，要使用这个中间件可以在 `app.js` 中添加下列代码：
-
-```javascript
-var express = require('express');
-var AV = require('leanengine');
-
-var app = express();
-// 加载 cookieSession 以支持 AV.User 的会话状态
-app.use(AV.Cloud.CookieSession({ secret: 'my secret', maxAge: 3600000, fetchUser: true }));
-```
-
-Koa 需要添加一个 `framework: 'koa'` 的参数：
-
-```javascript
-var app = koa();
-app.use(AV.Cloud.CookieSession({ framework: 'koa', secret: 'my secret', maxAge: 3600000, fetchUser: true }));
-```
-
-你需要传入一个 secret 用于加密 Cookie（必须提供），这个中间件会将 `AV.User` 的登录状态信息记录到 Cookie 中，用户下次访问时自动检查用户是否已经登录，如果已经登录，可以通过 `req.currentUser` 获取当前登录用户。
-
-`AV.Cloud.CookieSession` 支持的选项包括：
-
-* **fetchUser**：**是否自动 fetch 当前登录的 AV.User 对象。默认为 false。**  
-  如果设置为 true，每个 HTTP 请求都将发起一次 LeanCloud API 调用来 fetch 用户对象。如果设置为 false，默认只可以访问 `req.currentUser` 的 `id`（`_User` 表记录的 ObjectId）和 `sessionToken` 属性，你可以在需要时再手动 fetch 整个用户。
-* **name**：Cookie 的名字，默认为 `avos.sess`。
-* **maxAge**：设置 Cookie 的过期时间。
-
-**注意**：在 Node SDK 1.x 之后我们不再允许通过 `AV.User.current()` 获取登录用户的信息（详见 [升级到云引擎 Node.js SDK 1.0](leanengine-node-sdk-upgrade-1.html#废弃_currentUser)）：
-
-* 在云引擎方法中，通过 `request.currentUser` 获取用户信息。
-* 在网站托管中，通过 `request.currentUser` 获取用户信息。
-* 在后续的方法调用显示传递 user 对象。
-
-你可以这样简单地实现一个具有登录功能的站点：
-
-```javascript
-// 渲染登录页面
-app.get('/login', function(req, res) {
-  res.render('login.ejs');
-});
-
-// 处理登录请求（可能来自登录界面中的表单）
-app.post('/login', function(req, res) {
-  AV.User.logIn(req.body.username, req.body.password).then(function(user) {
-    console.log('signin successfully: %j', user);
-    res.saveCurrentUser(user); // 保存当前用户到 Cookie.
-    res.redirect('/profile'); // 跳转到个人资料页面
-  },function(error) {
-    //登录失败，跳转到登录页面
-    res.redirect('/login');
-  });
-})
-
-// 查看个人资料
-app.get('/profile', function(req, res) {
-  // 判断用户是否已经登录
-  if (req.currentUser) {
-    // 如果已经登录，发送当前登录用户信息。
-    res.send(req.currentUser);
-  } else {
-    // 没有登录，跳转到登录页面。
-    res.redirect('/login');
-  }
-});
-
-// 登出账号
-app.get('/logout', function(req, res) {
-  req.currentUser.logOut();
-  res.clearCurrentUser(); // 从 Cookie 中删除用户
-  res.redirect('/profile');
-});
-```
-
-一个简单的登录页面（`login.ejs`）可以是这样：
-
-```html
-<html>
-    <head></head>
-    <body>
-      <form method="post" action="/login">
-        <label>Username</label>
-        <input name="username"></input>
-        <label>Password</label>
-        <input name="password" type="password"></input>
-        <input class="button" type="submit" value="登录">
-      </form>
-    </body>
-  </html>
-```
-
-{% endblock %}
-
 {% block custom_session %}
-### 自定义 session
 有时候你需要将一些自己需要的属性保存在 session 中，你可以增加通用的 `cookie-session` 组件，详情可以参考 [express.js &middot; cookie-session](https://github.com/expressjs/cookie-session)。该组件和 `AV.Cloud.CookieSession` 组件可以并存。
 
 注意：express 框架的 `express.session.MemoryStore` 在我们云引擎中是无法正常工作的，因为我们的云引擎是多主机、多进程运行，因此内存型 session 是无法共享的，建议用 [express.js &middot; cookie-session 中间件](https://github.com/expressjs/cookie-session)。
 {% endblock %}
 
-{% block https_redirect %}
+{% block leancache %}
+首先添加相关依赖到 `package.json` 中：
 
+```json
+"dependencies": {
+  ...
+  "redis": "2.2.x",
+  ...
+}
+```
+
+然后可以使用下列代码获取 Redis 连接：
+
+```js
+var client = require('redis').createClient(process.env['REDIS_URL_<实例名称>']);
+// 建议增加 client 的 on error 事件处理，否则可能因为网络波动或 redis server 主从切换等原因造成短暂不可用导致应用进程退出。
+client.on('error', function(err) {
+  return console.error('redis err: %s', err);
+});
+```
+{% endblock %}
+
+{% block https_redirect %}
 Express:
 
 ```javascript
@@ -326,27 +412,6 @@ app.use(AV.Cloud.HttpsRedirect({framework: 'koa'}));
 ```
 {% endblock %}
 
-
-{% block custom_runtime %}
-目前{{fullName}}在项目框架中使用 {{platformName}} 4.x，开发者最好使用此版本进行开发。
-
-对于早期云引擎项目如果想使用 Node.js 4.x 版本，请在项目的 `package.json` 中为指定 `engine` 的版本，例如：
-
-```
-...
-"engines": {
-  "node": "4.x"
-},
-...
-```
-
-你还可以将版本设置为 `*` 来指定总是使用最新版本的 Node.js（目前是 Node.js 6）。
-
-**提示**：{{productName}} 0.12 和 4.x 差异较大，建议升级后充分测试。
-
-**提示**：如果 {{productName}} 不支持所指定的版本，则会默认使用 {{platformName}} 0.12 版本。
-{% endblock %}
-
 {% block code_calling_custom_variables %}
 ```javascript
 // 在云引擎 Node.js 环境中使用自定义的环境变量
@@ -355,30 +420,17 @@ console.log(MY_CUSTOM_VARIABLE);
 ```
 {% endblock %}
 
-{% block get_env %}
-```javascript
-var NODE_ENV = process.env.NODE_ENV || 'development';
-if (NODE_ENV === 'development') {
-  // 当前环境为「开发环境」，是由命令行工具启动的
-} else if(NODE_ENV == 'production') {
-  // 当前环境为「生产环境」，是线上正式运行的环境
-} else {
-  // 当前环境为「预备环境」
-}
-```
-{% endblock %}
-
 {% block loggerExample %}
 ```javascript
 console.log('hello');
-console.error('some error!')
+console.error('some error!');
 ```
 {% endblock %}
 
 {% block loggerExtraDescription %}
 你可以通过设置一个 `DEBUG=leancloud:request` 的环境变量来打印由 LeanCloud SDK 发出的网络请求。在本地调试时你可以通过这样的命令启动程序：
 
-```bash
+```sh
 env DEBUG=leancloud:request lean up
 ```
 
@@ -394,43 +446,16 @@ leancloud:request response(0) +220ms 200 {"results":[{"content":"1","createdAt":
 {% endblock %}
 
 {% block section_timezone %}
-## 时区问题
+需要注意 JavaScript 中 Date 类型的不同方法，一部分会返回 UTC 时间、一部分会返回当地时间（在中国区是北京时间）：
 
-因为某些原因，云引擎 2.0 默认使用的是 UTC 时间，这给很多开发者带来了困惑，所以我们着重讨论下时区问题。
+函数|时区|结果
+---|---|---
+`toISOString`|UTC 时间|2015-04-09T03:35:09.678Z
+`toJSON`（JSON 序列化时）|UTC 时间|2015-04-09T03:35:09.678Z
+`toUTCString`|UTC 时间|Thu, 09 Apr 2015 03:35:09 GMT
+`getHours`|UTC 时间|3
+`toString`（`console.log` 打印时）|当地时间|Thu Apr 09 2015 03:35:09 GMT+0000 (UTC)
+`toLocaleString`|当地时间|Thu Apr 09 2015 03:35:09 GMT+0000 (UTC)
 
-比如有这样一个时间：`2015-05-05T06:15:22.024Z` (ISO 8601 表示法)，最后末尾的 `Z` 表示该时间是 UTC 时间。
-
-上面的时间等价于：`2015-05-05T14:15:22.024+0800`，注意此时末尾是 `+0800` 表示该时间是东八区时间。这两个时间的「小时」部分相差了 8 小时。
-
-### 时区问题产生的原因
-
-很多开发者在时间处理上会忽略「时区」标志，导致最后总是莫名其妙的出现 8 小时的偏差。
-
-【场景一】某开发者开发的应用使用云引擎的主机托管功能做了一个网站，其中有时间格式的表单提交。某用户使用浏览器访问该网站，提交表单，时间格式为：`2015-05-05 14:15:22.024`，注意该时间没有「时区」标志。因为这个时间是浏览器生成的，而该用户浏览器上的时间通常是东八区时间，所以该业务数据希望表达的时间是「东八区的 14 点」。
-
-该时间 `2015-05-05 14:15:22.024` 提交到服务器，被转换为 Date 类型（JavaScript 代码：`new Date('2015-05-05 14:15:22.024')`）。因为云引擎 2.0 使用的是 UTC 时间，所以该时间会被处理为 `2015-05-05T14:15:22.024Z`，即「UTC 时间的 14 点」。导致最后获得的时间和期望时间相差了 8 小时。
-
-解决上面的办法很简单：时间格式带上时区标志。即浏览器上传时间时使用 `2015-05-05T14:15:22.024+0800`，这样不管服务端默认使用什么时区，带有时区的时间格式转换的 Date 都不会有歧义。
-
-【场景二】从数据库获取某记录的 `createdAt` 属性，假设值为：`2015-04-09T03:35:09.678Z`。因为云引擎默认时区是 UTC，所以一些时间函数的返回结果如下：
-
-函数|结果
----|---
-`toISOString`|2015-04-09T03:35:09.678Z
-`toLocaleString`|Thu Apr 09 2015 03:35:09 GMT+0000 (UTC)
-`toUTCString`|Thu, 09 Apr 2015 03:35:09 GMT
-`toString`|Thu Apr 09 2015 03:35:09 GMT+0000 (UTC)
-`getHours`|3，如果将 getHours 的结果返回给浏览器，或者作为业务数据使用，则会出现 8 小时的偏差。
-
-如果需要获取小时数据，解决办法是使用第三方的组件，比如 [moment-timezone](http://momentjs.com/timezone/)，通过下面的方式可以获得东八区的小时时间：
-
-```javascript
-var time = moment(obj.createdAt).tz('Asia/Shanghai');
-console.log('toString', time.toString());
-console.log('getHours', time.hours());
-```
-
-### 云引擎 2.0 和云引擎时区的差异
-
-为了方便大家的使用，更加符合通常的习惯，云引擎运行时环境（无沙箱的 Node.js 环境和 Python 环境）都是使用**东八区**作为默认时区。当然，我们仍然建议程序的时间字符串带有时区标志。
+提醒大家需要在向用户展示时注意区分，否则就会出现时间「偏差八小时」的现象。
 {% endblock %}

--- a/views/leanengine_webhosting_guide-node.md
+++ b/views/leanengine_webhosting_guide-node.md
@@ -151,7 +151,7 @@ app.use(function *(next) {
 
 ```
 
-使用 Koa 时建议按照前面 [package.json](#package.json) 一节将 Node.js 的版本设置为 `4.x` 以上。
+使用 Koa 时建议按照前面 [package.json](#package_json) 一节将 Node.js 的版本设置为 `4.x` 以上。
 
 ### 其他 Web 框架
 

--- a/views/leanengine_webhosting_guide-php.md
+++ b/views/leanengine_webhosting_guide-php.md
@@ -8,6 +8,9 @@
 {% set leanengine_middleware = '[LeanCloud PHP SDK](https://github.com/leancloud/php-sdk)' %}
 
 {% block custom_api_random_string %}
+{{productName}} 允许开发者自定义基于 HTTP（HTTPS） 的 API。
+例如，开发者如果想实现一个获取服务端时间的 API，可以在代码中如下做：
+
 打开 `./app.php` ，添加如下代码：
 
 ```php
@@ -20,11 +23,20 @@ $app->get('/time', function($req, $res) {
     return $response;
 });
 ```
+
+然后打开浏览器，访问 <http://localhost:3000/time>，浏览器应该会返回如下类似的内容：
+
+```json
+{"currentTime":"2016-02-01T09:43:26.223Z"}
+```
+
+部署到云端后，你可以通过 `http://{{var_app_domain}}.leanapp.cn/time` 来访问该 API。你的 iOS 或者 Android 的程序就可以构建一个 HTTP 请求获取服务端时间了。当然还是建议使用各 SDK 内置的获取服务器时间的 API，这里的例子只是演示。
 {% endblock %}
 
 {% block project_constraint %}
-{{fullName}} 项目必须有 `$PROJECT_DIR/public/index.php` 文件，该文件为整个项目的启动文件。
+你的项目需要遵循一定格式才会被云引擎识别并运行。
 
+{{fullName}} 项目必须有 `$PROJECT_DIR/public/index.php` 文件，该文件为整个项目的启动文件。
 {% endblock %}
 
 {% block project_start %}
@@ -155,8 +167,6 @@ $app->post("/upload", function($req, $res) {
 {% endblock %}
 
 {% block cookie_session %}
-### 处理用户登录和登出
-
 云引擎提供了一个 `LeanCloud\Storage\CookieStorage` 模块，用 Cookie 来维护用户（`User`）的登录状态，要使用它可以在 `app.php` 中添加下列代码：
 
 ```php
@@ -227,7 +237,6 @@ $app->get('/logout', function($req, $res) {
 {% endblock %}
 
 {% block custom_session %}
-### 自定义 session
 有时候你需要将一些自己需要的属性保存在会话中，我们建议使用 CookieStorage 来保存：
 
 ```php
@@ -254,7 +263,7 @@ $app->add(new SlimEngine());
 
 
 {% block custom_runtime %}
-PHP 云引擎暂不支持其它版本。
+PHP 云引擎目前只提供了 5.5 版本。
 {% endblock %}
 
 {% block get_env %}

--- a/views/leanengine_webhosting_guide.tmpl
+++ b/views/leanengine_webhosting_guide.tmpl
@@ -4,101 +4,60 @@
 {% set var_app_domain = '{应用的域名}' %}
 # 网站托管开发指南 &middot; {{platformName}}
 
-网站托管是云引擎的一个子模块，请确保在阅读本文档之前，你已阅读了 [云引擎服务概览](leanengine_overview.html)。
+网站托管是云引擎的一个子模块，允许你用 {{platformName}} 开发一个 Web 程序，提供云函数和 Hook，还可以提供静态文件的托管和自定义的路由、绑定你自己的域名。你可以用它为你的移动应用提供一个介绍和下载页、开发一个管理员控制台或完整的网站，或者运行一些必须在服务器端运行的自定义逻辑。
 
-使用你熟悉的语言开发一个 Web 程序，提供静态文件托管和动态路由，开发一个 Web 站点，拥有自己的二级域名；或者为移动应用提供一个介绍和下载页；或者开发一个管理员控制台。
+如果你还不知道如何创建云引擎项目，本地调试并部署到云端，可以先阅读一下 [云引擎快速入门](leanengine_quickstart.html)。
 
-如果还不知道如何创建云引擎项目，本地调试并部署到云端，请阅读 [云引擎快速入门](leanengine_quickstart.html)。
+在阅读本文档的同时，你还可以通过 [云引擎服务概览](leanengine_overview.html) 了解云引擎的全部功能、通过 [云引擎命令行工具使用详解](leanengine_cli.html) 了解命令行工具的用法、通过 [LeanCache 使用指南](leancache_guide.html) 了解云引擎提供的内存缓存服务，还可以在 [云引擎项目示例](leanengine_examples.html) 找到一些云引擎的示例项目，遇到问题时可以先检索一下 [云引擎常见问题和解答](leanengine_faq.html)。
 
-## 多语言支持
-
-云引擎支持多种语言的运行环境，你可以选择自己熟悉的语言开发应用：
+这篇文档以 {{platformName}} 为例，但云引擎还支持其他多种语言，你可以选择自己熟悉的技术栈进行开发：
 
 - [Node.js](leanengine_webhosting_guide-node.html)
 - [Python](leanengine_guide-python.html)
 - [PHP](leanengine_webhosting_guide-php.html)
 - [Java](leanengine_webhosting_guide-java.html)
 
-## 项目约束
-
-### 项目格式
-
-你的项目需要遵循一定格式才会被云引擎识别并运行。
+## 项目骨架
 
 {% block project_constraint %}{% endblock %}
 
 {% block project_start %}{% endblock %}
 
+{% block custom_runtime %}{% endblock %}
+
 ### 健康监测
 
-云引擎项目在部署启动时，部署服务会对新启动的应用进行 `ping` 监测（每隔 1 秒请求一次，一共 30 次），请求 URL 为 `/__engine/1/ping`，如果响应的 `statusCode` 为 `200` 则认为新的节点启动成功，整个部署才会成功；否则会收到 **应用启动检测失败** 类型的错误信息，导致部署失败。
+你的应用在启动时，云引擎的管理程序会每秒去检查你的应用是否启动成功，如果 **30 秒** 仍未启动成功，即认为启动失败；在之后应用正常运行的过程中，也会有定期的「健康监测」，以确保你的应用正常运行，如果健康监测失败，云引擎管理程序会自动重启你的应用。
 
-{% block ping %}{% endblock %}
+健康检查的 URL 包括你的应用首页（`/`）和 {{platformName}} SDK 负责处理的 `/__engine/1/ping`，只要 **两者之一** 返回了 HTTP 200 的响应，就视作成功。因此请确保你的程序使用了 {{platformName}} SDK，或你的应用 **首页能够正常地返回 HTTP 200** 响应。
 
-### Web 框架
+除此之外，为了支持云引擎的云函数和 Hook 功能，管理程序会使用 `/1.1/functions/_ops/metadatas` 这个 URL 和 {{platformName}} SDK 交互，请确保将这个 URL 交给 {{platformName}} SDK 处理，或 **返回一个 HTTP 404 表示不使用云函数** 和 Hook 相关的功能。
+
+{% block ping %}
+关于如何加载 {{platformName}} SDK，见下面的 [Web 框架](#Web 框架) 和 [LeanCloud SDK](#LeanCloud SDK) 小节。
+{% endblock %}
+
+## Web 框架
 
 {% block supported_frameworks%}{% endblock %}
 
-### 运行环境定制
-
-{% block custom_runtime %}{% endblock %}
-
-## 环境变量
-
-云引擎平台默认提供下列环境变量供应用使用：
-
-变量名|说明
----|---
-`LEANCLOUD_APP_ID`|当前应用的 App Id
-`LEANCLOUD_APP_KEY`|当前应用的 App Key
-`LEANCLOUD_APP_MASTER_KEY`|当前应用的 Master Key
-`LEANCLOUD_APP_ENV`|当前的应用环境：<ul><li>开发环境没有该环境变量，或值为 `development`（一般指本地开发）</li><li>预备环境值为 `stage`</li><li>生产环境值为 `production`</li></ul>
-`LEANCLOUD_APP_PORT`|当前应用开放给外网的端口，只有监听此端口，用户才可以访问到你的服务。
-`LEANCLOUD_APP_INSTANCE`|云引擎实例名称，在多实例环境可以通过此变量标示自己。
-`LEANCLOUD_REGION`|云引擎服务所在区域，值为 `CN` 或 `US`，分别表示国内节点和美国节点。
-
-**提示**：旧版云引擎使用的以 `LC_` 开头的环境变量（如 `LC_APP_ID`）已经被弃用。为了保证代码兼容性，`LC_` 变量在一段时间内依然有效，但未来可能会完全失效。为了避免报错，建议使用 `LEANCLOUD_` 变量来替换。
-
-### 自定义环境变量
-
-你也可以在 [云引擎 > 设置](/cloud.html?appid={{appid}}#/conf) 页面中添加自定义的环境变量。其中名字必须是字母、数字、下划线且以字母开头，值必须是字符串，修改环境变量后会在下一次部署时生效。
-
-按照一般的实践，可以将一些配置项存储在环境变量中，这样可以在不修改代码的情况下，修改环境变量并重新部署，来改变程序的行为；或者可以将一些第三方服务的 Secret Key 存储在环境变量中，避免这些密钥直接出现在代码中。
-
-{% block code_calling_custom_variables %}{% endblock %}
-
-## 预备环境和生产环境
-
-对于免费版应用，云引擎只有一个「生产环境」，对应的域名是 `{{var_app_domain}}.leanapp.cn`。
-
-专业版应用会有一个额外的「预备环境」，对应域名 `stg-{{var_app_domain}}.leanapp.cn`，两个环境所访问的都是同样的数据，你可以用预备环境测试你的云引擎代码，每次部署先部署到预备环境，测试通过后再发布到生产环境；如果你希望有一个独立数据源的测试环境，建议单独创建一个应用。
-
-<div class="callout callout-info">有时请求云引擎会遇到 **No Application Configured 的错误**，通常是因为对应的环境没有部署代码。例如免费版应用没有预备环境，或专业版应用尚未发布代码到生产环境。</div>
-
-关于免费版和专业版的更多差别，请参考 [云引擎运行方案](leanengine_plan.html)。
-
-有些时候你可能需要知道当前云引擎运行在什么环境（开发环境、预备环境或生产环境），从而做不同的处理：
-
-{% block get_env %}{% endblock %}
-
-你应该注意到了，我们在请求云引擎的时候，通过 REST API 的特殊的 HTTP 头 `X-LC-Prod`，来区分调用的环境。
-
-* 0 表示调用预备环境
-* 1 表示调用生产环境
-
-<div class="callout callout-info">如果在客户端想调用云引擎的预备环境，各个 SDK 都有类似于 `setProduction` 的方法，比如 [JavaScript SDK API &middot; `AV.setProduction(production)`](/api-docs/javascript/symbols/AV.html#.setProduction)，其中 `production` 设置为 `0` 则该 SDK 将请求预备环境；设置为 `1` 将请求生产环境，默认为 `1`。</div>
-
-## 存储数据
+## LeanCloud SDK
 
 {% block use_leanstorage %}{% endblock %}
 
 ## 部署
 
-### 使用命令行工具部署
+### 命令行部署
+
+在你的项目根目录运行：
+
+```sh
+lean deploy
+```
 
 使用命令行工具可以非常方便地部署、发布应用，查看应用状态，查看日志，甚至支持多应用部署。具体使用请参考 [命令行工具指南](leanengine_cli.html)。
 
-### 使用 Git 部署
+### Git 部署
 
 除此之外，还可以使用 git 仓库部署。你需要将项目提交到一个 git 仓库，我们并不提供源码的版本管理功能，而是借助于 git 这个优秀的分布式版本管理工具。我们推荐你使用 [GitHub](https://github.com/)、[Coding](https://coding.net/) 或者 [OSChina](http://git.oschina.net/) 这样第三方的源码托管网站，也可以使用你自己搭建的 git 仓库（比如 [Gitlab](http://gitlab.org/)）。
 
@@ -115,64 +74,40 @@ git push -u origin master
 
 设置好之后，今后需要部署代码时就可以在云引擎的部署界面直接点击「部署」了，默认会部署 master 分支的代码，你也可以在部署时填写分支、标签或具体的 Commit。
 
-### Gitlab 常见问题
+### 预备环境和生产环境
+对于免费版应用，云引擎只有一个「生产环境」，对应的域名是 `{{var_app_domain}}.leanapp.cn`。
 
-很多用户自己使用 [Gitlab](http://gitlab.org/)搭建了自己的源码仓库，有朋友会遇到无法部署到 LeanCloud 的问题，即使设置了 Deploy Key，却仍然要求输入密码。
+升级到专业版后会有一个额外的「预备环境」，对应域名 `stg-{{var_app_domain}}.leanapp.cn`，两个环境所访问的都是同样的数据，你可以用预备环境测试你的云引擎代码，每次修改先部署到预备环境，测试通过后再发布到生产环境；如果你希望有一个独立数据源的测试环境，建议单独创建一个应用。
 
-可能的原因和解决办法如下：
+<div class="callout callout-info">如果访问云引擎遇到「No Application Configured」的错误，通常是因为对应的环境还没有部署代码。例如免费版应用没有预备环境，或专业版应用尚未发布代码到生产环境。</div>
 
-* 确保你 gitlab 运行所在服务器的 /etc/shadow 文件里的 git（或者 gitlab）用户一行的 `!`修改为 `*`，原因参考 [Stackoverflow - SSH Key asks for password](http://stackoverflow.com/questions/15664561/ssh-key-asks-for-password)，并重启 SSH 服务：`sudo service ssh restart`。
-* 在拷贝 deploy key 时，确保没有多余的换行符号。
-* Gitlab 目前不支持有 comment 的 deploy key。早期 LeanCloud 用户生成的 deploy key 可能带 comment，这个 comment 是在 deploy key 的末尾 76 个字符长度的字符串，例如下面这个 deploy key：
+关于免费版和专业版的更多差别，请参考 [云引擎运行方案](leanengine_plan.html)。
 
-```
-ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA5EZmrZZjbKb07yipeSkL+Hm+9mZAqyMfPu6BTAib+RVy57jAP/lZXuosyPwtLolTwdyCXjuaDw9zNwHdweHfqOX0TlTQQSDBwsHL+ead/p6zBjn7VBL0YytyYIQDXbLUM5d1f+wUYwB+Cav6nM9PPdBckT9Nc1slVQ9ITBAqKZhNegUYehVRqxa+CtH7XjN7w7/UZ3oYAvqx3t6si5TuZObWoH/poRYJJ+GxTZFBY+BXaREWmFLbGW4O1jGW9olIZJ5/l9GkTgl7BCUWJE7kLK5m7+DYnkBrOiqMsyj+ChAm+o3gJZWr++AFZj/pToS6Vdwg1SD0FFjUTHPaxkUlNw== App dxzag3zdjuxbbfufuy58x1mvjq93udpblx7qoq0g27z51cx3's cloud code deploy key
-```
-其中最后 76 个字符：
+有些时候你可能需要知道当前云引擎运行在什么环境（开发环境、预备环境或生产环境），从而做不同的处理：
 
-```
-App dxzag3zdjuxbbfufuy58x1mvjq93udpblx7qoq0g27z51cx3's cloud code deploy key
-```
+{% block get_env %}{% endblock %}
 
-就是 comment，删除这段字符串后的 deploy key（如果没有这个字样的comment无需删除）保存到 gitlab 即可正常使用：
+在客户端 SDK 调用云函数时，可以通过 REST API 的特殊的 HTTP 头 `X-LC-Prod` 来区分调用的环境。
 
-```
-ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA5EZmrZZjbKb07yipeSkL+Hm+9mZAqyMfPu6BTAib+RVy57jAP/lZXuosyPwtLolTwdyCXjuaDw9zNwHdweHfqOX0TlTQQSDBwsHL+ead/p6zBjn7VBL0YytyYIQDXbLUM5d1f+wUYwB+Cav6nM9PPdBckT9Nc1slVQ9ITBAqKZhNegUYehVRqxa+CtH7XjN7w7/UZ3oYAvqx3t6si5TuZObWoH/poRYJJ+GxTZFBY+BXaREWmFLbGW4O1jGW9olIZJ5/l9GkTgl7BCUWJE7kLK5m7+DYnkBrOiqMsyj+ChAm+o3gJZWr++AFZj/pToS6Vdwg1SD0FFjUTHPaxkUlNw==
-```
+* `X-LC-Prod: 0` 表示调用预备环境
+* `X-LC-Prod: 1` 表示调用生产环境
 
-## 设置域名
+<div class="callout callout-info">客户端 SDK 都有类似于 `setProduction` 的方法，比如 [JavaScript SDK API 的 AV.setProduction(production)](/api-docs/javascript/symbols/AV.html#.setProduction)，其中 `production` 设置为 `0` 则该 SDK 将请求预备环境；设置为 `1` 将请求生产环境，默认为 `1`。</div>
 
-{% if node=='qcloud' %}
-首先，你需要到 `云引擎 > 设置` 页面找到 **Web 主机域名**，在这里填写你的域名：
-{% else %}
-首先，你需要到 [云引擎 > 设置](/cloud.html?appid={{appid}}#/conf) 页面找到 **Web 主机域名**，在这里填写你的域名：
-{% endif %}
+### 设置域名
 
-![image](images/cloud_code_web_setting.png)
+你可以在 {% if node=='qcloud' %}「云引擎 > 设置」{% else %}[云引擎 > 设置](/cloud.html?appid={{appid}}#/conf){% endif %} 的「Web 主机域名」部分，填写一个自定义的二级域名，例如你设置了 `myapp`，那么你就可以通过我们的二级域名来访问你的网站了：
 
-上面将应用的二级域名设置为 **myapp**，设置之后，你应该可以马上访问：
+- <http://myapp.leanapp.cn>（中国区）
+- <http://myapp.avosapps.us>（美国区）
 
-- http://myapp.leanapp.cn
-- http://myapp.avosapps.us
+<div class="callout callout-info">你可能需要至多几个小时的时间来等待 DNS 生效。</div>
 
-可能因为 DNS 生效延迟暂时不可访问，请耐心等待或者尝试刷新 DNS 缓存，如果还没有部署，你看到的应该是一个 404 页面。
+## 用户状态管理
 
-## Web 组件
+{% block cookie_session %}{% endblock %}
 
-### 自定义 API
-{{productName}} 允许开发者自定义基于 HTTP（HTTPS） 的 API。
-例如，开发者如果想实现一个获取服务端时间的 API，可以在代码中如下做：
-
-{% block custom_api_random_string %}
-{% endblock %}
-
-然后打开浏览器，访问 <http://localhost:3000/time>，浏览器应该会返回如下类似的内容：
-
-```json
-{"currentTime":"2016-02-01T09:43:26.223Z"}
-```
-
-部署到云端后，你可以通过 `http://{{var_app_domain}}.leanapp.cn/time` 来访问该 API。你的 iOS 或者 Android 的程序就可以构建一个 HTTP 请求获取服务端时间了。当然还是建议使用各 SDK 内置的获取服务器时间的 API，这里的例子只是演示。
+## 实现常见功能
 
 ### 发送 HTTP 请求
 
@@ -184,7 +119,7 @@ ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA5EZmrZZjbKb07yipeSkL+Hm+9mZAqyMfPu6BTAib+RVy
 
 {% block code_get_client_ip_address %}{% endblock %}
 
-### 上传文件
+### 文件上传
 托管在 {{productName}} 的网站项目可以直接使用内置的 LeanCloud {{sdk_name}} SDK 的 API 文件相关的接口直接处理文件的上传。
 
 假设前端 HTML 代码如下：
@@ -202,11 +137,19 @@ ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA5EZmrZZjbKb07yipeSkL+Hm+9mZAqyMfPu6BTAib+RVy
 
 {% block code_upload_file_sdk_function %}{% endblock %}
 
-{% block cookie_session %}{% endblock %}
+### Session
 
-{% block custom_session %}{% endblock %}
+{% block custom_session %}
+{{platformName}} 暂不支持。
+{% endblock %}
 
-### 自动重定向到 HTTPS
+### LeanCache
+
+{% block leancache %}{% endblock %}
+
+关于 LeanCache 的更多使用方法请看 [LeanCache 使用指南](leancache_guide.html)。
+
+### 重定向到 HTTPS
 
 为了安全性，我们可能会为网站加上 HTTPS 加密传输。我们的 {{productName}} 支持网站托管，同样会有这样的需求。
 
@@ -216,34 +159,62 @@ ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA5EZmrZZjbKb07yipeSkL+Hm+9mZAqyMfPu6BTAib+RVy
 
 部署并发布到生产环境之后，访问你的 {{productName}} 网站二级域名都会强制通过 HTTPS 访问。
 
-## 日志
+## 线上环境
 
-{% if node=='qcloud' %}
-`云引擎 / 日志`，可以查看云引擎的部署和运行日志，还可以通过日志级别进行筛选。
-{% else %}
-[云引擎 / 日志](/cloud.html?appid={{appid}}#/log)，可以查看云引擎的部署和运行日志，还可以通过日志级别进行筛选。
-{% endif %}
+### 环境变量
+
+云引擎平台默认提供下列环境变量供应用使用：
+
+变量名|说明
+---|---
+`LEANCLOUD_APP_ID`|当前应用的 App Id
+`LEANCLOUD_APP_KEY`|当前应用的 App Key
+`LEANCLOUD_APP_MASTER_KEY`|当前应用的 Master Key
+`LEANCLOUD_APP_ENV`|当前的应用环境：<ul><li>开发环境没有该环境变量，或值为 `development`（一般指本地开发）</li><li>预备环境值为 `stage`</li><li>生产环境值为 `production`</li></ul>
+`LEANCLOUD_APP_PORT`|当前应用开放给外网的端口，只有监听此端口，用户才可以访问到你的服务。
+`LEANCLOUD_APP_INSTANCE`|云引擎实例名称，在多实例环境可以通过此变量标示自己。
+`LEANCLOUD_REGION`|云引擎服务所在区域，值为 `CN` 或 `US`，分别表示国内节点和美国节点。
+
+<div class="callout callout-info">旧版云引擎使用的以 `LC_` 开头的环境变量（如 `LC_APP_ID`）已经被弃用。为了保证代码兼容性，`LC_` 变量在一段时间内依然有效，但未来可能会完全失效。为了避免报错，建议使用 `LEANCLOUD_` 变量来替换。</div>
+
+你也可以在 [云引擎 > 设置](/cloud.html?appid={{appid}}#/conf) 页面中添加自定义的环境变量。其中名字必须是字母、数字、下划线且以字母开头，值必须是字符串，修改环境变量后会在下一次部署时生效。
+
+按照一般的实践，可以将一些配置项存储在环境变量中，这样可以在不修改代码的情况下，修改环境变量并重新部署，来改变程序的行为；或者可以将一些第三方服务的 Secret Key 存储在环境变量中，避免这些密钥直接出现在代码中。
+
+{% block code_calling_custom_variables %}{% endblock %}
+
+### 日志
+
+在控制台的 {% if node=='qcloud' %}「云引擎 / 日志」{% else %}[云引擎 / 日志](/cloud.html?appid={{appid}}#/log){% endif %} 中可以查看云引擎的部署和运行日志，还可以通过日志级别进行筛选。
 
 应用的日志可以直接输出到「标准输出」或者「标准错误」，这些信息会分别对应日志的 `info` 和 `error` 级别，比如下列代码会在 info 级别记录参数信息：
 
 {% block loggerExample %}{% endblock %}
 
-**注意**：日志单行最大 4096 个字符，多余部分会被丢弃；日志输出频率大于 600 条/分钟，多余的部分会被丢弃。
+<div class="callout callout-info">日志单行最大 4096 个字符，多余部分会被丢弃；日志输出频率大于 600 条/分钟，多余的部分会被丢弃。</div>
 
 {% block loggerExtraDescription %}{% endblock %}
 
+### 时区
+
+在云引擎的中国区系统默认使用北京时间（`Asia/Shanghai`），美国区默认使用 UTC 时间。
+
 {% block section_timezone %}{% endblock %}
 
-## 域名备案
+### 依赖缓存
 
-**备案之前要求云引擎已经部署，并且网站内容和备案申请的内容一致。仅使用云引擎托管静态文件、未使用其他 LeanCloud 服务的企业用户，需要自行完成域名备案工作。**
+云引擎实现了一个缓存机制来加快构建的速度，所谓构建就是指你的应用在云引擎上安装依赖的过程，目测存在两种机制。
 
-如果需要备案，进入 [应用控制台 > 账号设置 > 域名备案](/settings.html#/setting/domainrecord)，按照步骤填写资料即可。
+Node.js 采用的：如果 `package.json` 和上次构建相比没有修改，就直接采用上次安装的依赖，只将新的应用代码替换上去。
 
-## 域名绑定
+Python、PHP、Java 采用的：每次构建结束时将依赖目录打包，下次构建时将上次的依赖包解压到原处，再运行包管理器来安装依赖，可以复用已有的依赖项。
 
-**国内节点绑定独立域名需要有 ICP 备案，只有主域名需要备案，二级子域名不需要备案；如果没有 ICP 备案，请参考 [域名备案](#域名备案)。**
+如果你遇到了与依赖安装有关的问题，可以在控制台部署时勾选「下载最新依赖」，或通过命令行工具部署时添加 `--noCache` 选项。
 
-如果需要域名绑定，进入 [应用控制台 > 账号设置 > 域名绑定](/settings.html#/setting/domainbind)，按照步骤填写资料即可。
+## 备案和自定义域名
 
+如果需要绑定自己的域名，进入 [应用控制台 > 账号设置 > 域名绑定](/settings.html#/setting/domainbind)，按照步骤填写资料即可。
 
+国内节点绑定独立域名需要有 ICP 备案，只有主域名需要备案，二级子域名不需要备案；如果没有 ICP 备案，请进入 [应用控制台 > 账号设置 > 域名备案](/settings.html#/setting/domainrecord)，按照步骤填写资料进行备案。
+
+<div class="callout callout-info">备案之前要求云引擎已经部署，并且网站内容和备案申请的内容一致。仅使用云引擎托管静态文件、未使用其他 LeanCloud 服务的企业用户，需要自行完成域名备案工作。</div>

--- a/views/tool_tips.md
+++ b/views/tool_tips.md
@@ -100,7 +100,7 @@
 * 想建立一个应用网站？我们提供 [网站托管](leanengine_guide-cloudcode.html#Web_Hosting)。
 * 想用好云引擎，请先熟悉 [JavaScript SDK 开发指南](leanstorage_guide-js.html)。
 * 云引擎 Web 主机托管，可以绑定备案过的独立域名，请在 [工单系统](https://leanticket.cn/t/leancloud) 提出技术申请。
-* 云引擎 Web 主机托管，我们可以协助你完成域名的备案，请参考 [域名备案](leanengine_guide-cloudcode.html#域名备案)。
+* 云引擎 Web 主机托管，我们可以协助你完成域名的备案，请在 [应用控制台 > 账户设置 > 域名备案](/settings.html#/setting/domainrecord) 操作。
 
 ## 其他
 {% if node!='qcloud' %}


### PR DESCRIPTION
主要是修改了网站托管的模板和 Node.js 的实现；对 PHP 和 Java 的修改仅为了适应模板的修改，并没有实质性修改。

修改包括：

* 重排小标题，减少小标题层级，在 Node.js 页面默认展开所有小标题
* 移动「GitLab 部署常见问题」到 FAQ 页面
* 更新有关项目结构、健康检查部分的描述
* 精简对时区问题的描述
* 补充 LeanCahce 示例、Koa 示例