### PR TITLE
Update installation doc

### DIFF
--- a/views/sdk_setup-ios.md
+++ b/views/sdk_setup-ios.md
@@ -1,7 +1,8 @@
 # Objective-C SDK 安装指南
 
 ## 自动安装
-通过 [CocoaPods](http://www.cocoapods.org) 来安装可以最大化地简化安装过程。
+
+通过 [CocoaPods](http://www.cocoapods.org) 安装可以最大化地简化安装过程。
 
 首先，在项目根目录下的 Podfile 文件中添加以下 pods：
 
@@ -11,24 +12,45 @@ pod 'AVOSCloudIM'             # 实时通信模块
 pod 'AVOSCloudCrashReporting' # 错误报告模块
 ```
 
-然后在项目根目录执行 `pod install` 命令，就能将 SDK 集成到您的项目中。
+<div class="callout callout-info">注意：从版本 v3.4.0 开始，不再根据平台区分 pod 名称。同一个模块在所有平台上的 pod 名称是一样的。CocoaPods 会根据 Podfile 中的 platform 信息安装相应的源文件。旧的 pod（带有平台后缀的 pod，例如 AVOSCloud-watchOS、AVOSCloudIM-OSX 等）不再更新。如果要更新到 v3.4.0 及以后的版本，请将 pod 的平台后缀去掉。</div>
+
+然后在项目根目录执行 `pod install` 命令，执行成功后，SDK 就集成到项目中了。
 
 
 ## 手动安装
 
-首先，将指定版本的源码 clone 到您的项目根目录：
+### 下载源码
+
+首先，SDK 仓库 clone 到您的项目根目录：
 
 ```sh
-git clone --depth 1 https://github.com/leancloud/objc-sdk.git leancloud-objc-sdk
+git clone "https://github.com/leancloud/objc-sdk.git" leancloud-objc-sdk
+```
+
+然后 checkout 版本。SDK 的版本号是通过 tag 标记的，可以使用以下命令 checkout 最新版：
+
+```sh
+cd leancloud-objc-sdk
+
+git checkout $(git describe --tags $(git rev-list --tags --max-count=1))
 ```
 
 如果您希望使用 CrashReporting 模块，还需要进一步 clone submodule：
 
 ```sh
-cd leancloud-objc-sdk
-
 git submodule update --init
 ```
+
+### 集成 SDK
+
+接下来，需要把 SDK 集成到您的项目中。集成的方式有两个选择：
+
+1. 将 SDK 的 xcodeproj 直接添加到您的项目中；
+2. 先将 SDK 编译成 framework，再将编译好的 framework 添加到您的项目中。
+
+**注意：两个方法任选一种即可。**
+
+#### 集成 xcodeproj
 
 将 `AVOS/AVOS.xcodeproj` 项目文件拖进您的项目，作为 subproject。就像下面这样：
 
@@ -39,6 +61,22 @@ git submodule update --init
 ![img](images/quick_start/ios/link-binary.png)
 
 注意，作为示例，上图选择了两个支持 iOS 平台的 frameworks（AVOSCloud 与 AVOSCloudIM 模块）。实际情况下，您应该根据应用支持的平台以及需要用到的服务来进行选择。
+
+#### 编译 framework
+
+如果您不希望集成 xcodeproj，也可以先把 SDK 编译成 framework。我们提供了一键编译脚本来完成这个工作。
+
+在 SDK 的根目录执行以下命令进行一键编译：
+
+```sh
+ruby build-frameworks.rb
+```
+
+待命令执行完毕，就可以在 AVOS/AVOS.xcodeproj/build 目录下找到编译好的 frameworks。
+
+注意，为了区分平台，frameworks 添加了平台后缀，例如 AVOSCloud-iOS.framework。您需要先将平台后缀删掉后，再添加到的项目中，否则会产生编译错误。
+
+### 添加系统依赖
 
 然后添加 SDK 依赖的系统 framework 和 library：
 
@@ -62,13 +100,13 @@ git submodule update --init
 
 ## 初始化 SDK
 
-打开 AppDelegate 文件，添加下列导入语句到头部：
+打开 AppDelegate 文件，导入基础模块：
 
 ```objc
 #import <AVOSCloud/AVOSCloud.h>
 ```
 
-然后粘贴下列代码到 `application:didFinishLaunchingWithOptions` 函数内：
+然后粘贴下列代码到 `application:didFinishLaunchingWithOptions:` 方法中：
 
 ```objc
 // 如果使用美国站点，请加上下面这行代码：

--- a/views/start/ios_start.md
+++ b/views/start/ios_start.md
@@ -1,5 +1,6 @@
 #### 自动安装
-通过 [CocoaPods](http://www.cocoapods.org) 来安装可以最大化地简化安装过程。
+
+通过 [CocoaPods](http://www.cocoapods.org) 安装可以最大化地简化安装过程。
 
 首先，在项目根目录下的 Podfile 文件中添加以下 pods：
 
@@ -9,24 +10,45 @@ pod 'AVOSCloudIM'             # 实时通信模块
 pod 'AVOSCloudCrashReporting' # 错误报告模块
 ```
 
-然后在项目根目录执行 `pod install` 命令，就能将 SDK 集成到您的项目中。
+<div class="callout callout-info">注意：从版本 v3.4.0 开始，不再根据平台区分 pod 名称。同一个模块在所有平台上的 pod 名称是一样的。CocoaPods 会根据 Podfile 中的 platform 信息安装相应的源文件。旧的 pod（带有平台后缀的 pod，例如 AVOSCloud-watchOS、AVOSCloudIM-OSX 等）不再更新。如果要更新到 v3.4.0 及以后的版本，请将 pod 的平台后缀去掉。</div>
+
+然后在项目根目录执行 `pod install` 命令，执行成功后，SDK 就集成到项目中了。
 
 
 #### 手动安装
 
-首先，将指定版本的源码 clone 到您的项目根目录：
+##### 下载源码
+
+首先，SDK 仓库 clone 到您的项目根目录：
 
 ```sh
-git clone --depth 1 https://github.com/leancloud/objc-sdk.git leancloud-objc-sdk
+git clone "https://github.com/leancloud/objc-sdk.git" leancloud-objc-sdk
+```
+
+然后 checkout 版本。SDK 的版本号是通过 tag 标记的，可以使用以下命令 checkout 最新版：
+
+```sh
+cd leancloud-objc-sdk
+
+git checkout $(git describe --tags $(git rev-list --tags --max-count=1))
 ```
 
 如果您希望使用 CrashReporting 模块，还需要进一步 clone submodule：
 
 ```sh
-cd leancloud-objc-sdk
-
 git submodule update --init
 ```
+
+##### 集成 SDK
+
+接下来，需要把 SDK 集成到您的项目中。集成的方式有两个选择：
+
+1. 将 SDK 的 xcodeproj 直接添加到您的项目中；
+2. 先将 SDK 编译成 framework，再将编译好的 framework 添加到您的项目中。
+
+**注意：两个方法任选一种即可。**
+
+###### 集成 xcodeproj
 
 将 `AVOS/AVOS.xcodeproj` 项目文件拖进您的项目，作为 subproject。就像下面这样：
 
@@ -37,6 +59,22 @@ git submodule update --init
 ![img](images/quick_start/ios/link-binary.png)
 
 注意，作为示例，上图选择了两个支持 iOS 平台的 frameworks（AVOSCloud 与 AVOSCloudIM 模块）。实际情况下，您应该根据应用支持的平台以及需要用到的服务来进行选择。
+
+###### 编译 framework
+
+如果您不希望集成 xcodeproj，也可以先把 SDK 编译成 framework。我们提供了一键编译脚本来完成这个工作。
+
+在 SDK 的根目录执行以下命令进行一键编译：
+
+```sh
+ruby build-frameworks.rb
+```
+
+待命令执行完毕，就可以在 AVOS/AVOS.xcodeproj/build 目录下找到编译好的 frameworks。
+
+注意，为了区分平台，frameworks 添加了平台后缀，例如 AVOSCloud-iOS.framework。您需要先将平台后缀删掉后，再添加到的项目中，否则会产生编译错误。
+
+##### 添加系统依赖
 
 然后添加 SDK 依赖的系统 framework 和 library：
 
@@ -60,13 +98,13 @@ git submodule update --init
 
 #### 初始化 SDK
 
-打开 AppDelegate 文件，添加下列导入语句到头部：
+打开 AppDelegate 文件，导入基础模块：
 
 ```objc
 #import <AVOSCloud/AVOSCloud.h>
 ```
 
-然后粘贴下列代码到 `application:didFinishLaunchingWithOptions` 函数内：
+然后粘贴下列代码到 `application:didFinishLaunchingWithOptions:` 方法中：
 
 ```objc
 // 如果使用美国站点，请加上下面这行代码：


### PR DESCRIPTION
更新 Objective-C SDK 的安装文档，主要增加了手动编译 framework 的步骤，并增加了 checkout 某个版本的命令。 

@leancloud/docs-editor 快速入门这个页面的标题好像有点小。
@nicecui 对应 [objc-sdk/#34](https://github.com/leancloud/objc-sdk/issues/34) 这个 issue。
@leancloud/ios-group 