### PR TITLE
fix(docs): [存储] _User 表默认关闭 find 权限的目的是为了限制登录用户查询到其他用户的数据

### DIFF
--- a/views/leanstorage_guide.tmpl
+++ b/views/leanstorage_guide.tmpl
@@ -918,7 +918,10 @@ Todo 的 `whereCreated`（创建 Todo 时的位置）是一个 `{{geoPointObject
 
 {% endblock %}
 ### 用户的查询
-请注意，**新创建的应用的用户表 `_User` 默认关闭了 find 权限**。你可以通过 Class 权限设置打开 find 权限，请参考 [数据与安全 {{middot}} Class 级别的权限](data_security.html#Class_级别的_ACL)。我们推荐开发者在 [云引擎](leanengine_overview.html) 中封装用户查询，只查询特定条件的用户，避免开放用户表的全部查询权限。
+
+为了安全起见，**新创建的应用的 `_User` 表默认关闭了 find 权限**，这样每位用户登录后只能查询到自己在 `_User` 表中的数据，无法查询其他用户的数据。如果需要让其查询其他用户的数据，建议单独创建一张表来保存这类数据，并开放这张表的 find 查询权限。
+
+设置数据表权限的方法，请参考 [数据与安全 {{middot}} Class 级别的权限](data_security.html#Class_级别的_ACL)。我们推荐开发者在 [云引擎](leanengine_overview.html) 中封装用户查询，只查询特定条件的用户，避免开放 `_User` 表的全部查询权限。
 
 查询用户代码如下：
 {% block code_query_user %}{% endblock %}


### PR DESCRIPTION
Closes #1656