### PR TITLE
Add example for querying all conversations include system

### DIFF
--- a/views/realtime_guide-objc.md
+++ b/views/realtime_guide-objc.md
@@ -1425,6 +1425,37 @@ NSDate *yesterday = [today dateByAddingTimeInterval: -86400.0];
 ```
 {% endblock %}
 
+{% block conversation_query_active_between %}
+```objc
+- (void)tomQueryActiveConversationsBetween {
+    // Tom 创建了一个 client，用自己的名字作为 clientId
+    self.client = [[AVIMClient alloc] initWithClientId:@"Tom"];
+
+    // Tom 打开 client
+    [self.client openWithCallback:^(BOOL succeeded, NSError *error) {
+        NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
+        [dateFormatter setDateFormat:@"yyyy-MM-dd"];
+
+        // 查询最后一条消息的时间大于 2017-01-01 的对话
+        AVIMConversationQuery *query1 = [[AVIMClient defaultClient] conversationQuery];
+        [query1 whereKey:@"lm" greaterThan:[dateFormatter dateFromString:@"2017-01-01"]];
+
+        // 查询最后一条消息的时间小于 2017-02-01 的对话
+        AVIMConversationQuery *query2 = [[AVIMClient defaultClient] conversationQuery];
+        [query1 whereKey:@"lm" lessThan:[dateFormatter dateFromString:@"2017-02-01"]];
+
+        // 将以上两个查询组合成一个查询
+        AVIMConversationQuery *query = [AVIMConversationQuery andQueryWithSubqueries:@[ query1, query2 ]];
+
+        // 执行查询
+        [query findConversationsWithCallback:^(NSArray *objects, NSError *error) {
+            NSLog(@"找到 %ld 个对话！", [objects count]);
+        }];
+    }];
+}
+```
+{% endblock %}
+
 {% block conversation_query_count %}
 ```objc
 - (void)tomQueryConversationByCombination {

--- a/views/realtime_guide-objc.md
+++ b/views/realtime_guide-objc.md
@@ -1397,6 +1397,34 @@ NSDate *yesterday = [today dateByAddingTimeInterval: -86400.0];
 ```
 {% endblock %}
 
+{% block conversation_query_all_include_system %}
+```objc
+- (void)tomQueryAllConversationsIncludeSystem {
+    // Tom 创建了一个 client，用自己的名字作为 clientId
+    self.client = [[AVIMClient alloc] initWithClientId:@"Tom"];
+
+    // Tom 打开 client
+    [self.client openWithCallback:^(BOOL succeeded, NSError *error) {
+        // 查询 Tom 参与过的对话，即 m = Tom
+        AVIMConversationQuery *query1 = [[AVIMClient defaultClient] conversationQuery];
+        [query1 whereKey:@"m" equalTo:@"Tom"];
+
+        // 查询系统对话，即 sys = true
+        AVIMConversationQuery *query2 = [[AVIMClient defaultClient] conversationQuery];
+        [query2 whereKey:@"sys" equalTo:@(YES)];
+
+        // 将以上两个查询组合成一个查询
+        AVIMConversationQuery *query = [AVIMConversationQuery orQueryWithSubqueries:@[ query1, query2 ]];
+
+        // 执行查询
+        [query findConversationsWithCallback:^(NSArray *objects, NSError *error) {
+            NSLog(@"找到 %ld 个对话！", [objects count]);
+        }];
+    }];
+}
+```
+{% endblock %}
+
 {% block conversation_query_count %}
 ```objc
 - (void)tomQueryConversationByCombination {

--- a/views/realtime_guide.tmpl
+++ b/views/realtime_guide.tmpl
@@ -813,24 +813,28 @@ Black 发现对话名字不够酷，他想修改成「聪明的喵星人」 ，�
 
 组合查询的概念就是把诸多查询条件合并成一个查询，再交给 SDK 去云端进行查询。
 
-{% block conversation_query_chaining %}{% endblock %}例如，要查询年龄小于 18 岁，并且关键字包含「教育」的对话：
+##### OR 查询
 
-{% block conversation_query_combination %}
-```
-- 初始化 ClientId = Tom
-- Tom 登录
-- 构建查询条件：attr.keywords 包含「教育」、attr.age < 18
-- 执行查询
-```
-{% endblock %}
-
-再例如，要查询自己参与过的对话，包括系统对话，可以这样构建查询：
+OR 操作表示多个查询条件符合其中任意一个即可。例如，要查询自己参与过的对话，包括系统对话，可以这样构建查询：
 
 {% block conversation_query_all_include_system %}
 ```
 - 初始化 ClientId = Tom
 - Tom 登录
 - 构建组合查询：m 等于 Tom 并且 sys 等于 true
+- 执行查询
+```
+{% endblock %}
+
+##### AND 查询
+
+AND 操作表示多个查询条件必须同时符合。例如要查询一段时间内活跃的对话，可以这样构建查询：
+
+{% block conversation_query_active_between %}
+```
+- 初始化 ClientId = Tom
+- Tom 登录
+- 构建组合查询：lm 在某个时间段内
 - 执行查询
 ```
 {% endblock %}

--- a/views/realtime_guide.tmpl
+++ b/views/realtime_guide.tmpl
@@ -824,6 +824,17 @@ Black 发现对话名字不够酷，他想修改成「聪明的喵星人」 ，�
 ```
 {% endblock %}
 
+再例如，要查询自己参与过的对话，包括系统对话，可以这样构建查询：
+
+{% block conversation_query_all_include_system %}
+```
+- 初始化 ClientId = Tom
+- Tom 登录
+- 构建组合查询：m 等于 Tom 并且 sys 等于 true
+- 执行查询
+```
+{% endblock %}
+
 只要查询构建得合理，开发者完全不需要担心组合查询的性能。
 
 {% block conversation_query_cache %}


### PR DESCRIPTION
新增示例以查询自己参与过的所有对话，包括系统对话。取代 PR #1740 。

之前有用户对 ConversationQuery 默认不返回系统对话有疑惑，因此在文档中描述一下。请其他 SDK 也补充一下示例代码。在各自的实时通信文档中新建名为 conversation_query_all_include_system 的 block 即可。

@leeyeh @daweibayu @leancloud/sdker 