### PR TITLE
chore: correctly display {{var}} in code sample

### DIFF
--- a/custom/js/app.js
+++ b/custom/js/app.js
@@ -45,6 +45,15 @@ angular.module("app").controller("AppCtrl", ['$scope', '$http', '$timeout','$com
                 location.reload();
             });
         }
+        // 2017-03-24 output undefined variables as is(surrounded by double curl braces)
+        $scope.mustache = function(val){
+          if ( typeof $scope[val] == 'undefined' ){
+            return '{{' + val + '}}';
+          }
+          else {
+            return $scope[val];
+          }
+        }
 
         window.addEventListener("message", receiveMessage, false);
 

--- a/views/_helper.md
+++ b/views/_helper.md
@@ -8,6 +8,26 @@
 
 注意将其 namespace 设置为 **`docs`**，与其他宏文件如 `_storage.njk`、`_sms.njk` 区别开来。
 
+## mustache
+
+```
+{% raw %}{{ docs.mustache('todos','','',true) }}
+{{ docs.mustache('todos','div',{},true) }}
+{{ docs.mustache('todos') }}
+{{ docs.htmlTag("samp", {"ng-non-bindable": null,class: "bubble"}) }}{% endraw %}
+```
+
+结果：
+
+```
+{{ docs.mustache('todos','','',true) }}
+{{ docs.mustache('todos','div','',true) }}
+{{ docs.mustache('todos') }}
+{{ docs.mustache('todos') }}
+{{ docs.htmlTag("samp", {"ng-non-bindable": null,class: "bubble"}) }}
+```
+
+
 ## `note()`
 
 ```nunjucks

--- a/views/_helper.njk
+++ b/views/_helper.njk
@@ -37,26 +37,36 @@
   {%- endif %}
 {%- endmacro %}
 
-{% macro mustache(name, tag="code", attrs={"ng-non-bindable": null}) -%}
-  {% if tag | trim != "" -%}
-    {{ htmlTag(tag, attrs, "{{" + name + "}}") }}
+{% macro mustache(name, tag="code", attrs={"ng-non-bindable": null}, showEvenIfUndefined=false) -%}
+  {%- if tag | trim != "" -%}
+    {{ htmlTag(tag, attrs, "{{" + jsMustache(name, showEvenIfUndefined) + "}}") }}
   {%- else -%}
-    {% raw %}{{{% endraw %}{{name}}{% raw %}}}{% endraw %}
+    {% raw %}{{{% endraw %}{{jsMustache(name, showEvenIfUndefined)}}{% raw %}}}{% endraw %}
   {%- endif %}
+{%- endmacro %}
+
+{% macro jsMustache(name, showEvenIfUndefined) -%}
+  {%- if showEvenIfUndefined == true -%}
+    {{jsMustache_prefix}}mustache('{{name}}'){{jsMustache_suffix}}
+  {%- else -%}
+    {{name}}
+  {%- endif -%}
 {%- endmacro %}
 
 {% macro htmlTag(name="", attrs="", slot="") -%}
   {% if name | trim != "" -%}
-    <{{name}} {{ objectStringify(attrs) | trim }}>{{ slot | safe }}</{{name}}>
+    <{{name}}{{ objectStringify(attrs) }}>{{ slot | safe }}</{{name}}>
   {%- else -%}
     {{ slot | safe }}
   {%- endif %}
 {%- endmacro %}
 
 {% macro objectStringify(obj) -%}
-  {% for key, value in obj -%}
-    {% if value == null %}{{key}} {% else %}{{key}}="{{value}}" {% endif %}
-  {%- endfor %}
+  {%- if obj != '' -%}
+    {%- for key, value in obj -%}
+       {%- if value == null %} {{key}}{% else %} {{key}}="{{value}}"{% endif -%}
+    {%- endfor -%}
+  {%- endif %}
 {%- endmacro %}
 
 {% macro bubbleWrap() -%}

--- a/views/weapp.md
+++ b/views/weapp.md
@@ -1,3 +1,4 @@
+{% import "views/_helper.njk" as docs %}
 # 在微信小程序中使用 {% if node == 'qcloud' %}TAB{% else %}LeanCloud{% endif %}
 
 微信小程序是一个全新的跨平台移动应用平台，LeanCloud 为小程序提供一站式后端云服务，为你免去服务器维护、证书配置等繁琐的工作，大幅降低你的开发和运维成本。本文说明了如何在微信小程序中使用 LeanCloud 提供的各项服务。
@@ -59,14 +60,14 @@ Page({
   },
 });
 ```
-
-<pre ng-non-bindable><code class="lang-html">&lt;!-- pages/todos/todos.wxml --&gt;
-&lt;block wx:for=&quot;&lbrace;&lbrace;todos&rbrace;&rbrace;&quot; wx:for-item=&quot;todo&quot; wx:key=&quot;objectId&quot;&gt;
-  &lt;text data-id=&quot;&lbrace;&lbrace;todo.objectId}}&quot;&gt;
-    &lbrace;&lbrace;todo.content}}
-  &lt;/text&gt;
-&lt;/block&gt;
-</code></pre>
+```html
+<!-- pages/todos/todos.wxml -->
+<block wx:for="{{ docs.mustache('todos','',{},true) }}" wx:for-item="todo" wx:key="objectId">
+  <text data-id="{{ docs.mustache('todo.objectId','',{},true) }}">
+    {{ docs.mustache('todo.content','',{},true) }}
+  </text>
+</block>
+```
 
 使用 `include` 得到的嵌套对象也可以直接在视图层通过 `.` 访问到：
 
@@ -85,10 +86,10 @@ Page({
   },
 });
 ```
-
-<pre ng-non-bindable><code class="lang-html">&lt;!-- pages/student/student.wxml --&gt;
-&lt;image src="&lbrace;&lbrace;student.avatar.url}}&quot;&gt;&lt;/image&gt;
-</code></pre>
+```html
+<!-- pages/student/student.wxml -->
+<image src="{{ docs.mustache('student.avatar.url','','',true) }}"></image>
+```
 
 ### 文件存储
 
@@ -187,9 +188,7 @@ AV.User.loginWithWeapp().then(user => {
 }).catch(console.error);
 ```
 
-<div class="callout callout-info">
-验证手机号码功能要求在控制台的应用设置中启用「用户注册时，向注册手机号码发送验证短信」。
-</div>
+{{ docs.note("验证手机号码功能要求在控制台的应用设置中启用「用户注册时，向注册手机号码发送验证短信」。") }}
 
 #### 绑定现有用户
 如果你的应用已经在使用 LeanCloud 的用户系统，或者用户已经通过其他方式注册了你的应用（比如在 Web 端通过用户名密码注册），可以通过在小程序中调用 `AV.User#linkWithWeapp()` 来关联已有的账户：


### PR DESCRIPTION
add `{% import "views/_helper.njk" as docs %}` to the first line of
.md/.tmpl
then use `{{ docs.mustache(‘var’,’’,’’,true) }}`
output: `{{mustache(‘var’)}}` which will be rendered by Angular as
`{{var}}`