### PR TITLE
fix: [IM] iOS 离线消息推送通知并不是默认关闭的

### DIFF
--- a/views/realtime_guide-android.md
+++ b/views/realtime_guide-android.md
@@ -769,8 +769,8 @@ jerry.open(new AVIMClientCallback() {
 ```
 {% endblock %}
 
-{% block offlineMessage_android %}
-**Android 聊天服务是和后台的推送服务共享连接的，所以只要有网络就永远在线，不需要专门做推送。**消息达到后，你可以根据用户的设置来判断是否需要弹出通知。网络断开时，我们为每个对话保存 20 条离线消息。
+{% block offlineMessage %}
+{{ docs.note("**Android 聊天服务是和后台的推送服务共享连接的，所以只要有网络就永远在线，不需要专门做推送。**消息达到后，你可以根据用户的设置来判断是否需要弹出通知。网络断开时，我们为每个对话保存 20 条离线消息。") }}
 {% endblock %}
 
 {% block message_unread_message_count %}

--- a/views/realtime_guide-objc.md
+++ b/views/realtime_guide-objc.md
@@ -465,7 +465,7 @@ typedef NS_ENUM(NSInteger, YourCustomMessageType) {
 {% block messagePolicy_sent %}{% endblock %}
 
 {% block offlineMessage %}
-这样 iOS 平台上的用户就可以收到消息推送了。当然，前提是应用本身申请到了 RemoteNotification 权限，也将正确的推送证书上传到了 LeanCloud 控制台。
+当然，前提是应用本身申请到了 RemoteNotification 权限，并且开发者也已经把正确的推送证书上传到了 LeanCloud 控制台。
 {% endblock %}
 
 {% block message_sent_ack_switch %}

--- a/views/realtime_guide.tmpl
+++ b/views/realtime_guide.tmpl
@@ -475,15 +475,13 @@ SDK 会在 Conversation 上维护 `unreadMessagesCount` 字段，这个字段在
 - 用户正在某个对话页面聊天，并在这个对话中收到了消息时
 {% endif %}
 
-#### 离线消息通知
+#### 离线消息推送通知
 
-离线消息通知是 SDK 默认的未读消息处理方式。不管是单聊还是群聊，当用户 A 发出消息后，如果目标对话的部分用户当前不在线，LeanCloud 云端可以提供离线推送的方式将消息提醒发送至客户端。
+离线消息推送通知是 SDK 默认的未读消息处理方式。不管是单聊还是群聊，当用户 A 发出消息后，如果目标对话的部分用户当前不在线，LeanCloud 云端可以提供离线推送的方式将消息提醒发送至客户端。{% block offlineMessage %}{% endblock %}
 
-{% block offlineMessage_android %}{% endblock %}
-
-{%  if segment_code == 'objc' or segment_code == 'dotnet' %}这一功能默认是关闭的，可以通过多种方式的设置来触发它，操作方法请参考 [实时通信概览 &middot; 离线推送通知](realtime_v2.html#离线推送通知)。{% endif %}
-
-{% block offlineMessage %}{% endblock %}
+{%  if segment_code !== 'android' %}
+我们也提供多种自定义推送通知的方式，操作方法请参考 [实时通信概览 · 离线推送通知](realtime_v2.html#离线推送通知)。
+{% endif %}
 
 ### 消息类详解
 {% block message_Relation_intro %}{% endblock %}


### PR DESCRIPTION
Closes https://github.com/leancloud/paas/issues/964