### PR TITLE
Update AVIMSignature action

### DIFF
--- a/views/realtime_guide-objc.md
+++ b/views/realtime_guide-objc.md
@@ -1837,16 +1837,13 @@ imClient.signatureDataSource = signatureDelegate;
  对一个操作进行签名. 注意:本调用会在后台线程被执行
  @param clientId - 操作发起人的 id
  @param conversationId － 操作所属对话的 id
- @param action － 操作的种类，主要有：
-                "join": 表示操作发起人要加入对话
-                "invite": 表示邀请其他人加入对话
-                "kick": 表示从对话中踢出部分人
+ @param action － @see AVIMSignatureAction
  @param clientIds － 操作目标的 id 列表
  @return 一个 AVIMSignature 签名对象.
  */
 - (AVIMSignature *)signatureWithClientId:(NSString *)clientId
                           conversationId:(NSString *)conversationId
-                                  action:(NSString *)action
+                                  action:(AVIMSignatureAction)action
                        actionOnClientIds:(NSArray *)clientIds;
 ```
 


### PR DESCRIPTION
适配最新 SDK

用 typedef NSString * const AVIMSignatureAction 替换 NSString * 类型。
虽然参数类型变了，但没有兼容问题，都是 NSString * 类型。