### PR TITLE
make ServiceRegion stand out

### DIFF
--- a/views/sdk_setup-objc.md
+++ b/views/sdk_setup-objc.md
@@ -103,10 +103,13 @@ ruby build-framework.rb
 然后粘贴下列代码到 `application:didFinishLaunchingWithOptions:` 方法中：
 
 ```objc
-{% if node != 'qcloud' %}// 使用美国站点需要增加以下代码：
-// [AVOSCloud setServiceRegion:AVServiceRegionUS];{% endif %}
-
 [AVOSCloud setApplicationId:@"{{appid}}" clientKey:@"{{appkey}}"];
+```
+
+使用 **美国节点** 需要增加以下代码：
+
+```objc
+[AVOSCloud setServiceRegion:AVServiceRegionUS];
 ```
 
 如果想跟踪统计应用的打开情况，后面还可以添加下列代码：


### PR DESCRIPTION
美国节点需单独设置 `AVServiceRegionUS`，在安装指南中需突出说明。原文档以注释的形式显示容易被忽略。

来自工单反馈： https://leanticket.cn/tickets/17500
