### PR TITLE
Replace channelId URL

### DIFF
--- a/views/android_push_guide.md
+++ b/views/android_push_guide.md
@@ -55,7 +55,7 @@ PushService.setDefaultPushCallback(this, PushDemo.class);
 ```
 ### Android 8.0 推送适配
 
-在调用 `AVOSCloud.initialize` 之前，需要先调用 `PushService.setDefaultChannelId(context, channelid)` 设置通知展示的默认 `channel`，否则消息无法展示。Channel ID 的解释请阅读 Google 官方文档 [Creating a notification](https://developer.android.com/guide/topics/ui/notifiers/notifications.html#CreateNotification)。
+在调用 `AVOSCloud.initialize` 之前，需要先调用 `PushService.setDefaultChannelId(context, channelid)` 设置通知展示的默认 `channel`，否则消息无法展示。Channel ID 的解释请阅读 Google 官方文档 [Creating a notification](https://developer.android.com/training/notify-user/channels.html)。
 
 ## 订阅频道
 


### PR DESCRIPTION
文档对 Channel ID 的说明链接地址有误，替换为正确的。