### PR TITLE
fix: 移除代码换行的样式

### DIFF
--- a/comment.js
+++ b/comment.js
@@ -5,7 +5,7 @@ var request = require('request-promise');
 
 var sessionToken = process.env.DOC_COMMENT_TOKEN
 var commentServer = process.env.COMMENT_SERVER || 'https://comment.leanapp.cn'
-var commentDoms = 'p,pre';
+var commentDoms = 'p';
 
 exports.release = function(docSite) {
   return request({

--- a/custom/less/bootstrap/code.less
+++ b/custom/less/bootstrap/code.less
@@ -44,8 +44,8 @@ pre {
   margin: 0 0 (@line-height-computed / 2);
   font-size: (@font-size-base - 1); // 14px to 13px
   line-height: @line-height-base;
-  word-break: break-all;
-  word-wrap: break-word;
+  overflow-x: auto;
+  overflow-wrap:normal;
   color: @pre-color;
   background-color: @pre-bg;
   border: 1px solid @pre-border-color;
@@ -56,7 +56,6 @@ pre {
     padding: 0;
     font-size: inherit;
     color: inherit;
-    white-space: pre-wrap;
     background-color: transparent;
     border-radius: 0;
   }

--- a/custom/less/section-docs.less
+++ b/custom/less/section-docs.less
@@ -213,8 +213,6 @@ body {
 
   pre {
     margin-bottom: 18px;
-    // fix inline comment indicator not showing in overflowed container
-    overflow: visible;
   }
 
   li > pre {

--- a/custom/less/theme-core.less
+++ b/custom/less/theme-core.less
@@ -933,7 +933,6 @@ textarea {
 
 code {
   font-size: 96%;
-  word-wrap: break-word;
 
   &.bstooltip {
     text-decoration: underline;


### PR DESCRIPTION
因为代码容器 pre 需要横向滚动，原评论指示器不再能显示，因此去掉代码的评论功能