### PR TITLE
android mixpush: fix image link

### DIFF
--- a/views/android_mixpush_guide.md
+++ b/views/android_mixpush_guide.md
@@ -184,7 +184,7 @@ LeanCloud 云端只有在**满足以下全部条件**的情况下才会使用华
 
 > 注意：这需要在华为控制台发送推送消息的时候指定 intentUri 才可行，在 LeanCloud 控制台还无法发送类似的推送请求，我们会尽快完善这部分功能。
 
-![image](/images/HMS-pushData.png)
+![image](images/HMS-pushData.png)
 
 ### 参考 demo
 我们提供了一个 [最新的华为推送 demo](https://github.com/leancloud/mixpush-demos/tree/master/huawei)，可供你在接入过程中参考。


### PR DESCRIPTION
Change absolute linking to relative linking,
to fix 404 in production environment.

resolve #2828