### PR TITLE
创建 conversation 时指定 unique 参数为真

### DIFF
--- a/views/chatkit-ios.md
+++ b/views/chatkit-ios.md
@@ -393,7 +393,9 @@ ChatListViewController.h 需导入头文件 `#import <ChatKit/LCChatKit.h>`,示�
 - (void)createConversationBtnClick{
 // clientId 是聊天对象 AUser 对象的 objectId。例如下面这个是用户「李四」的 objectId：
     NSString *clientId = @"5a5b995cac502e006e2e1391";
-    [[LCChatKit sharedInstance].client createConversationWithName:@"创建第一个会话" clientIds:@[clientId]callback:^(AVIMConversation *conversation, NSError *error)
+    [[LCChatKit sharedInstance].client createConversationWithName:@"创建第一个会话"
+      clientIds:@[clientId] options:AVIMConversationOptionUnique
+      callback:^(AVIMConversation *conversation, NSError *error)
         {
            [conversation sendMessage:[AVIMTextMessage messageWithText:@"你好，小王" attributes:nil]
                               callback:^(BOOL succeeded, NSError *error) {

--- a/views/realtime-guide-beginner.md
+++ b/views/realtime-guide-beginner.md
@@ -684,7 +684,7 @@ tom.createConversation(Arrays.asList("Jerry","Mary"), "Tom & Jerry & friends", n
    });
 ```
 ```cs
-var conversation = await tom.CreateConversationAsync(new string[]{ "Jerry","Mary" },"Tom & Jerry & friends");
+var conversation = await tom.CreateConversationAsync(new string[]{ "Jerry","Mary" }, name:"Tom & Jerry & friends", isUnique:true);
 ```
 
 ### 群发消息

--- a/views/realtime-guide-beginner.md
+++ b/views/realtime-guide-beginner.md
@@ -664,7 +664,9 @@ tom.createConversation({
 ```objc
 // Jerry 建立了与朋友们的会话
 NSArray *friends = @[@"Jerry", @"Mary"];
-[tom createConversationWithName:@"Tom & Jerry & friends" clientIds:friends callback:^(AVIMConversation *conversation, NSError *error) {
+[tom createConversationWithName:@"Tom & Jerry & friends" clientIds:friends
+  options:AVIMConversationOptionUnique
+  callback:^(AVIMConversation *conversation, NSError *error) {
     if (!error) {
         NSLog(@"创建成功");
     }

--- a/views/realtime-guide-beginner.md
+++ b/views/realtime-guide-beginner.md
@@ -322,7 +322,8 @@ public Task<AVIMConversation> CreateConversationAsync(string member = null,
 3. `attributes`：对话的自定义属性，可选。上面示例代码没有指定额外属性，开发者如果指定了额外属性的话，以后其他成员可以通过 AVIMConversation 的接口获取到这些属性值。附加属性在 `_Conversation` 表中被保存在 `attr` 列中。
 5. `unique/isUnique` 或者是 `AVIMConversationOptionUnique`：唯一对话标志位，可选。
   - 如果设置为唯一对话，云端会根据完整的成员列表先进行一次查询，如果已经有正好包含这些成员的对话存在，那么就返回已经存在的对话，否则才创建一个新的对话。
-  - 如果不指定 unique 标志为，那么每次调用 `createConversation` 接口都会创建一个新的对话。
+  - 如果指定 unique 标志为假，那么每次调用 `createConversation` 接口都会创建一个新的对话。
+  - 未指定 unique 时，Java SDK 默认值为真，其他 SDK 默认值为假（未来会改为默认值为真）。  
   - 从通用的聊天场景来看，不管是 Tom 发出「创建和 Jerry 单聊对话」的请求，还是从 Jerry 发出「创建和 Tom 单聊对话」的请求，或者 Tom 以后再次发出创建和 Jerry 单聊对话的请求，都应该是同一个对话才是合理的，否则可能因为聊天记录的不同导致用户混乱。所以我们***建议开发者明确指定 unique 标志为 true***。
 4. 对话类型的其他标志，可选参数，例如 `transient/isTransient` 表示「聊天室」，`tempConv/tempConvTTL` 和 `AVIMConversationOptionTemporary` 用来创建「临时对话」等等。什么都不指定就表示创建普通对话，对于这些标志位的含义我们先不管，以后会有说明。
 
@@ -659,6 +660,7 @@ tom.createConversation({
   members: ['Jerry','Mary'],
   // 对话名称
   name: 'Tom & Jerry & friends',
+  unique: true,
 }).catch(console.error);
 ```
 ```objc

--- a/views/realtime-guide-senior.md
+++ b/views/realtime-guide-senior.md
@@ -906,7 +906,9 @@ self.client = [[AVIMClient alloc] initWithClientId:@"Tom"];
 // Tom 打开 client
 [self.client openWithCallback:^(BOOL succeeded, NSError *error) {
     // Tom 建立了与 Jerry 的会话
-    [self.client createConversationWithName:@"猫和老鼠" clientIds:@[@"Jerry"] callback:^(AVIMConversation *conversation, NSError *error) {
+    [self.client createConversationWithName:@"猫和老鼠" clientIds:@[@"Jerry"]
+      options:AVIMConversationOptionUnique
+      callback:^(AVIMConversation *conversation, NSError *error) {
         // Tom 发了一条消息给 Jerry
 
         AVIMMessageOption *option = [[AVIMMessageOption alloc] init];


### PR DESCRIPTION
- 新版的 rtm 指南大部分地方都已经指定了 unique 参数，
这个 pr 补充了少数几处 js/objc/c# 未指定的代码示例，并补充了现各 SDK 默认值的说明。
- 新版的 Java SDK 已默认启用了 unique。
- REST API 已在 #2874 中修改。

resolve #2858