### PR TITLE
fix(mysql): typo in php sample

### DIFF
--- a/views/leandb_mysql_guide.md
+++ b/views/leandb_mysql_guide.md
@@ -61,7 +61,9 @@ mysqlPool.queryAsync('SELECT 1 + 1 AS solution').then( rows => {
 
 ```php
 try {
-  $pdo = new PDO("mysql:host={${getenv('MYSQL_HOST_MYRDB')}}:{${getenv('MYSQL_HOST_MYRDB')}};dbname=test", getenv('MYSQL_ADMIN_USER_MYRDB'), getenv('MYSQL_ADMIN_PASSWORD_MYRDB'));
+  $mysqlHost = getenv('MYSQL_HOST_MYRDB');
+  $mysqlPort = getenv('MYSQL_PORT_MYRDB');
+  $pdo = new PDO("mysql:host=$mysqlHost:$mysqlPort;dbname=test", getenv('MYSQL_ADMIN_USER_MYRDB'), getenv('MYSQL_ADMIN_PASSWORD_MYRDB'));
 
   foreach($pdo->query('SELECT 1 + 1 AS solution') as $row) {
     print "The solution is {$row['solution']}";


### PR DESCRIPTION
The second usage of environment variable `MYSQL_HOST_MYRDB`
should be replaced with `MYSQL_PORT_MYRDB` instead.