### PR TITLE
fix(leanengine): LEANCLOUD_APP_ENV value

### DIFF
--- a/views/leanengine_webhosting_guide-python.md
+++ b/views/leanengine_webhosting_guide-python.md
@@ -141,7 +141,7 @@ if env == 'development':
 elif env == 'production':
   # 当前环境为「生产环境」，是线上正式运行的环境
   do_some_thing()
-elif env == 'staging':
+elif env == 'stage':
   # 当前环境为「预备环境」
   do_some_thing()
 ```


### PR DESCRIPTION
Unedr LeanEngine's staging environment,
`LEANCLOUD_APP_ENV` (used by python sdk) is `stage`, not `staging`.
`staging` is the value of `NODE_ENV`,
used by nodejs sdk.