### PR TITLE
fix(python): typo in before_update hook definition

### DIFF
--- a/views/leanengine_cloudfunction_guide-python.md
+++ b/views/leanengine_cloudfunction_guide-python.md
@@ -144,7 +144,6 @@ def after_user_save(user):
 @engine.before_update('Review')
 def before_hook_object_update(obj):
     # 如果 comment 字段被修改了，检查该字段的长度
-    assert obj.updated_keys == ['clientValue']
     if 'comment' not in obj.updated_keys:
         # comment 字段没有修改，跳过检查
         return


### PR DESCRIPTION
I guess the sample code is edited based on python-sdk unit tests.
This statement is copied from unit tests,
and was forgotten to delete.