### PR TITLE
fix(LeanEngine): typo

### DIFF
--- a/views/leanengine_cloudfunction_guide-node.md
+++ b/views/leanengine_cloudfunction_guide-node.md
@@ -50,7 +50,7 @@ AV.Cloud.define('averageStars', function(request) {
 `Request` 会作为参数传入到云函数中，Request 上的属性包括：
 
 * `params: object`：客户端发送的参数对象，当使用 `rpc` 调用时，也可能是 `AV.Object`。
-* `currentUser?: AV.User`：客户端所关联的用户（根据客户端发送的 `LC-Session` 头）。
+* `currentUser?: AV.User`：客户端所关联的用户（根据客户端发送的 `X-LC-Session` 头）。
 * `sessionToken?: string`：客户端发来的 sessionToken（`X-LC-Session` 头）。
 * `meta: object`：有关客户端的更多信息，目前只有一个 `remoteAddress` 属性表示客户端的 IP。
 

--- a/views/leanengine_cloudfunction_guide-php.md
+++ b/views/leanengine_cloudfunction_guide-php.md
@@ -85,7 +85,7 @@ Cloud::start();
 传递给云函数的参数依次为：
 
 * `$params: array`：客户端发送的参数。
-* `$user: User`：客户端所关联的用户（根据客户端发送的 `LC-Session` 头）。
+* `$user: User`：客户端所关联的用户（根据客户端发送的 `X-LC-Session` 头）。
 * `$meta: array`：有关客户端的更多信息，目前只有一个 `$meta['remoteAddress']` 属性表示客户端的 IP。
 
 {% endblock %}


### PR DESCRIPTION
according to leancloud/leanengine-node-sdk
74d167636d5f77b949cf131c2d9dc9651fd77812