### PR TITLE
feat(rest): describe base url

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -251,7 +251,7 @@ module.exports = function(grunt) {
             masterkey: '{{masterkey}}',
             sign_masterkey: "{{sign_masterkey}}",
             sign_appkey: '{{sign_appkey}}',
-            host: '{{domain}}',
+            host: '$LC_API_HOST',
             engineDomain: engineDomainMap[grunt.option('theme')] || engineDomainMap['cn']
           }
         }

--- a/views/custom-api-domain-guide.md
+++ b/views/custom-api-domain-guide.md
@@ -61,8 +61,7 @@ xxx.example.com.	3600	IN	CNAME	avoscloud.com.
 
 #### REST API
 
-* 非云函数的访问，需要在代码中将 `api.leancloud.cn` 或 `<# appid 前八位 #>.api.lncld.net` 域名替换为 `xxx.example.com`。
-* 通过 REST API 访问云函数，需要将 `<# appid 前八位 #>.engine.lncld.net` 域名替换为 `xxx.example.com`。
+参考 [REST API 使用详解](rest_api.html#base-url) 配置。
 
 #### JavaScript SDK
 

--- a/views/leanengine-rest-api.md
+++ b/views/leanengine-rest-api.md
@@ -13,9 +13,20 @@ LeanCloud 云端提供的统一的访问云函数的接口，所有的客户端 
 
 ## Base URL
 
-LeanCloud 云函数的 base URL 同样为绑定的自定义域名，参见 [REST API 使用详解](rest_api.html#base-url)，
-但 LeanCloud 国际版云函数的 base URL 为 `appid前八位.engine.lncldglobal.com`,
-华北、华东节点的临时域名为 `appid前八位.engine.lncld.net`、`appid前八位.engine.lncldapi.com`。
+LeanCloud 云函数的 base URL 为绑定的 API 自定义域名。
+
+LeanCloud 国际版暂不支持绑定 API 自定义域名，国际版云函数需使用如下域名：
+
+```
+appid前八位.engine.lncldglobal.com
+```
+
+如果暂时没有绑定域名，访问云函数接口可以临时使用如下域名（仅供测试和原型开发阶段使用，不保证可用性）：
+
+| 节点 | 临时域名 |
+| - | - |
+| 华北 | appid前八位.engine.lncld.net |
+| 华东 | appid前八位.engine.lncldapi.com |
 
 ## 预备环境和生产环境
 

--- a/views/leanengine-rest-api.md
+++ b/views/leanengine-rest-api.md
@@ -11,6 +11,12 @@ LeanCloud 云端提供的统一的访问云函数的接口，所有的客户端 
 
 我们推荐使用 [Postman](http://www.getpostman.com/) 来调试 REST API，我们的社区中有一篇 [使用 Postman 调试 REST API 教程](https://forum.leancloud.cn/t/postman-rest-api/8638)。
 
+## Base URL
+
+LeanCloud 云函数的 base URL 同样为绑定的自定义域名，参见 [REST API 使用详解](rest_api.html#base-url)，
+但 LeanCloud 国际版云函数的 base URL 为 `appid前八位.engine.lncldglobal.com`,
+华北、华东节点的临时域名为 `appid前八位.engine.lncld.net`、`appid前八位.engine.lncldapi.com`。
+
 ## 预备环境和生产环境
 
 在客户端通过 REST API 调用云函数时，可以设置 HTTP 头 `X-LC-Prod` 来区分调用的环境。

--- a/views/rest_api.md
+++ b/views/rest_api.md
@@ -50,19 +50,6 @@ appid前八位.api.lncldglobal.com
 
 [api-domain]: custom-api-domain-guide.html
 
-建议在测试文档中的 curl 命令前设置如下环境变量
-（假定绑定的 API 域名为 `xxx.example.com`）：
-
-```sh
-export LC_API_HOST=xxx.example.com
-```
-
-Windows 环境将 `export` 换成 `set` 即可：
-
-```
-set LC_API_HOST=xxx.example.com
-```
-
 如果暂时没有绑定域名，可以临时使用如下域名（仅供测试和原型开发阶段使用，不保证可用性）：
 
 | 节点 | 临时域名 |

--- a/views/rest_api.md
+++ b/views/rest_api.md
@@ -38,6 +38,37 @@ Postman 还支持自动生成多种语言（库）调用 REST API 的代码。
 
 ![Postman 中点击 code，在弹出对话框中选择语言（库）](images/postman-generate-code.png)
 
+### Base URL
+
+文档中的所有 API URL 的 Base URL 为绑定的 [API 自定义域名][api-domain]。
+
+LeanCloud 国际版暂不支持绑定 API 自定义域名，需使用如下域名：
+
+```
+appid前八位.api.lncldglobal.com
+```
+
+[api-domain]: custom-api-domain-guide.html
+
+建议在测试文档中的 curl 命令前设置如下环境变量
+（假定绑定的 API 域名为 `xxx.example.com`）：
+
+```sh
+export LC_API_HOST=xxx.example.com
+```
+
+Windows 环境将 `export` 换成 `set` 即可：
+
+```
+set LC_API_HOST=xxx.example.com
+```
+
+如果暂时没有绑定域名，可以临时使用如下域名（仅供测试和原型开发阶段使用，不保证可用性）：
+
+| 节点 | 临时域名 |
+| - | - |
+| 华北 | appid前八位.api.lncld.net |
+| 华东 | appid前八位.api.lncldapi.com |
 
 ### 对象
 
@@ -575,7 +606,7 @@ POST 和 PUT 请求可能触发[云引擎的 hook 函数][hooks]，可以通过�
 * `X-LC-Prod: 0` 表示调用预备环境
 * `X-LC-Prod: 1` 表示调用生产环境
 
-默认（未指定 `X-LC-Prod` 头）调用生产环境的 hook 函数。 
+默认（未指定 `X-LC-Prod` 头）调用生产环境的 hook 函数。
 
 [hooks]: https://leancloud.cn/docs/leanengine_cloudfunction_guide-node.html#hash1095356413
 

--- a/views/sdk_setup.tmpl
+++ b/views/sdk_setup.tmpl
@@ -784,6 +784,7 @@ leancloud.init("{{appid}}", "{{appkey}}")
 use \LeanCloud\Client;
 // 参数依次为 App Id、App Key、Master Key
 Client::initialize("{{appid}}", "{{appkey}}", "{{masterkey}}");
+{{host}} = "xxx.example.com" // 假定绑定的 API 自定义域名为 xxx.example.com
 Client::setServerUrl("https://{{host}}"); // 0.7.0 及以上版本支持
 ```
 {% endif %}
@@ -958,6 +959,8 @@ AVRealtime.WebSocketLog(Debug.Log);
 ```sh
 ping "{{host}}"
 ```
+
+`{{host}}` 为绑定的 API 自定义域名。
 
 如果当前网路正常将会得到如下响应：
 


### PR DESCRIPTION
- prepare for future changes (prefer custom api domain)
- more compatible with zh-docs.leancloud.app