### PR TITLE
fix(UI): hide unnecessary elements on mobile

### DIFF
--- a/templates/include/doc-nav.html
+++ b/templates/include/doc-nav.html
@@ -1,4 +1,4 @@
-<header class="doc-subnav" role="banner">
+<header class="doc-subnav mobile-hide" role="banner">
   <div class="container-fluid">
     <nav class="" role="navigation">
       <ul class="nav navbar-nav">

--- a/templates/include/header.html
+++ b/templates/include/header.html
@@ -82,7 +82,7 @@
         <!-- hide search input on the home page -->
         {% if basename != "index" %}
           <!-- <form role="search" action="https://newdoc.leanapp.cn/search" method="get">-->
-            <div class="app-search">
+            <div class="app-search mobile-hide">
               <input id="site-search" name="q" type="text" class="form-control" placeholder="搜索文档&hellip;">
             </div>
           <!-- </form> -->

--- a/templates/layouts/template.swig
+++ b/templates/layouts/template.swig
@@ -20,7 +20,7 @@
 
   <div class="row">
 
-    <div class="sidebar-gruntfile-trigger  col-sm-3" id="left-nav">
+    <div class="sidebar-gruntfile-trigger mobile-hide col-sm-3" id="left-nav">
 
       <div class="sidebar-affix-shadow sidebar-hover-off">
 


### PR DESCRIPTION
文档内导航的作用是帮助用户快速找到一个页面/小节，并非相关页面/小节的唯一入口。隐藏导航因解决「进入一篇文档时可视区域内大部分都是导航」和「页面滚动时因为导航的伸缩而跳来跳去」这两个痛点所带来的优势应该是可以弥补缺少 shortcuts 所带来的缺陷的。

close #1712