### PR TITLE
fix(sms): sms template syntax

### DIFF
--- a/views/rest_sms_api.md
+++ b/views/rest_sms_api.md
@@ -189,14 +189,14 @@ curl -X POST \
 
 短信模板的语法遵循 [Handlebars](http://handlebarsjs.com/)，举例如下：
 
-<samp class="bubble" ng-non-bindable>Hi {{ docs.mustache("username") }}，欢迎注册{{ docs.mustache("name") }}应用。您可以通过验证码：{{ docs.mustache("code") }} 进行注册。本条短信将在{{ docs.mustache("ttl") }}分钟后自行销毁，请尽快使用【签名】
+<samp class="bubble" ng-non-bindable>Hi {{ docs.mustache("{username}") }}，欢迎注册{{ docs.mustache("{name}") }}应用。您可以通过验证码：{{ docs.mustache("{code}") }} 进行注册。本条短信将在{{ docs.mustache("{ttl}") }}分钟后自行销毁，请尽快使用【签名】
 </samp>
 
 * **code** 是我们帮你生成的验证码，可以通过 `/1.1/verifySmsCode/<code>` 校验。
 * **ttl** 是短信有效期，单位分钟，默认为 10 分钟。
 * **name** 是应用名称
 
-这三个内置字段会自动填充，你当然也可以添加自定义变量，形如 {{ docs.mustache("var") }}。
+这三个内置字段会自动填充，你当然也可以添加自定义变量，形如 {{ docs.mustache("{var}") }}。
 
 ### 短信模板审核
 
@@ -571,7 +571,7 @@ curl -X POST \
 
 1. 模板用途明确：通知类短信，比如活动通知、消息通知等。或者验证类短信，要求有验证码。
 2. 短信用途不得违反国家法律法规，下列短信是严格禁止的：房产类、中奖类、违法类（谣言、诈骗等）、赌博类等。
-3. [模板语法正确](sms-guide.html#模板变量)：我们仅支持 handlebars 语法，变量是以两个大括号括起来，类似 {{ docs.mustache("var") }}。
+3. [模板语法正确](sms-guide.html#模板变量)：我们仅支持 handlebars 语法，变量是以三个大括号括起来，类似 {{ docs.mustache("{var}") }}。
 4. 默认短信签名是应用名，你也可以在模板里设置短信签名，签名的要求请参考 [短信签名说明](sms-guide.html#短信签名)。
 
 如果你创建的短信模板被拒绝，请注意查收邮件，查看里面的拒绝原因等。如果还有疑问，请及时与我们联系。

--- a/views/sms-guide.md
+++ b/views/sms-guide.md
@@ -503,7 +503,7 @@ cloud.verify_sms_code('186xxxxxxxx', '123456')
 假设提交的短信模板的类型为「通知类」，内容如下：
 
 {% call docs.bubbleWrap() -%}
-尊敬的的用户，您的订单号：{{ docs.mustache("order_id") }} 正在派送，请保持手机畅通，我们的快递员随时可能与您联系，感谢您的订阅。 
+尊敬的的用户，您的订单号：{{ docs.mustache("{order_id}") }} 正在派送，请保持手机畅通，我们的快递员随时可能与您联系，感谢您的订阅。 
 {% endcall %}
 
 并且模板名称为 `Order_Notice`，并且为已经拥有了一个审核通过的签名叫做「天天商城」，签名的名称叫做 `sign_BuyBuyBuy` ，当模板通过审批后就可以调用如下代码发送这条通知类的短信：
@@ -622,7 +622,7 @@ cloud.request_sms_code("186xxxxxxxx",
 在模板中还可以使用<u>系统预留变量</u>，在短信发送时，它们会被自动填充，开发者**无法**对其重新赋值：
 
 {% call docs.bubbleWrap() -%}
-欢迎注册{{ docs.mustache("name") }}应用！请使用验证码{{ docs.mustache("code") }}来完成注册。该验证码将在{{ docs.mustache("ttl") }}分钟后失效，请尽快使用。
+欢迎注册{{ docs.mustache("{name}") }}应用！请使用验证码{{ docs.mustache("{code}") }}来完成注册。该验证码将在{{ docs.mustache("{ttl}") }}分钟后失效，请尽快使用。
 {% endcall %}
 
 - `name`：应用名称
@@ -638,7 +638,7 @@ cloud.request_sms_code("186xxxxxxxx",
 【正确范例】
 
 {% call docs.bubbleWrap() -%}
-XX房东您好，租客{{ docs.mustache("guest_name") }}（手机号码：{{ docs.mustache("guest_phone") }}）于{{ docs.mustache("payment_create_time") }}向您支付了房租。租金为{{ docs.mustache("rent_price") }}元，房屋地址在{{ docs.mustache("rent_addr") }}。请关注微信公众号：XX租房。XX租房APP下载地址：http://example.com/download.html
+XX房东您好，租客{{ docs.mustache("{guest_name}") }}（手机号码：{{ docs.mustache("{guest_phone}") }}）于{{ docs.mustache("{payment_create_time}") }}向您支付了房租。租金为{{ docs.mustache("{rent_price}") }}元，房屋地址在{{ docs.mustache("{rent_addr}") }}。请关注微信公众号：XX租房。XX租房APP下载地址：http://example.com/download.html
 {% endcall %}
 
 #### 链接
@@ -646,7 +646,7 @@ XX房东您好，租客{{ docs.mustache("guest_name") }}（手机号码：{{ doc
 短信中的 URL 不允许**全部**设置为变量，这样是为了确保安全，防止病毒以及不良信息的传播。错误范例如下：
 
 {% call docs.bubbleWrap() -%}
-尊敬的会员您好，您的订单（订单号{{ docs.mustache("orderId") }}）已确认支付。5周年庆新品降价！大牌奢品上演底价争霸，低至2折！BV低至888元！阿玛尼低至199元！都彭长款钱包仅售499元！杜嘉班纳休闲鞋仅售1399元！周年庆家居专场千元封顶现已开启！{{ docs.mustache("download_link") }} 客服电话400-881-6609 回复TD退订
+尊敬的会员您好，您的订单（订单号{{ docs.mustache("{orderId}") }}）已确认支付。5周年庆新品降价！大牌奢品上演底价争霸，低至2折！BV低至888元！阿玛尼低至199元！都彭长款钱包仅售499元！杜嘉班纳休闲鞋仅售1399元！周年庆家居专场千元封顶现已开启！{{ docs.mustache("{download_link}") }} 客服电话400-881-6609 回复TD退订
 {% endcall %}
 
 {{ docs.alert("以上通知内容包含了象 <u>打折</u>、<u>降价</u>、<u>仅售</u> 这类营销推广的敏感词语，容易导致审批无法通过，因此请谨慎使用或改用 [营销类短信](#营销短信)。") }}
@@ -654,7 +654,7 @@ XX房东您好，租客{{ docs.mustache("guest_name") }}（手机号码：{{ doc
 但是 URL 中可以包含变量，比如：
 
 {% call docs.bubbleWrap() -%}
-亲，您的宝贝已上路，快递信息可以通过以下链接查询：http://www.sf-express.com/cn/#search/{{ docs.mustache("bill_number") }} 
+亲，您的宝贝已上路，快递信息可以通过以下链接查询：http://www.sf-express.com/cn/#search/{{ docs.mustache("{bill_number}") }} 
 {% endcall %}
 
 #### 通知类模板
@@ -662,7 +662,7 @@ XX房东您好，租客{{ docs.mustache("guest_name") }}（手机号码：{{ doc
 【正确范例】
 
 {% call docs.bubbleWrap() -%}
-恭喜您获得关注广州体彩微信送“排列三”的活动彩票，您的号码是第{{ docs.mustache("phase") }}期的：{{ docs.mustache("num") }}。开奖时间为{{ docs.mustache("date") }}，请关注公众号—开奖信息查询中奖状态。
+恭喜您获得关注广州体彩微信送“排列三”的活动彩票，您的号码是第{{ docs.mustache("{phase}") }}期的：{{ docs.mustache("{num}") }}。开奖时间为{{ docs.mustache("{date}") }}，请关注公众号—开奖信息查询中奖状态。
 {% endcall %}
 
 〖错误范例〗


### PR DESCRIPTION
Use `{{{var}}}` instead of `{{var}}`
to avoid Handlebars HTML encoding special characters such as & and <.

related forum post: https://forum.avoscloud.com/t/amp/3276