### PR TITLE
fix: cn-e1 supported thumbnails long long ago.

### DIFF
--- a/views/leanstorage_guide.tmpl
+++ b/views/leanstorage_guide.tmpl
@@ -4989,7 +4989,7 @@ file.getThumbnailUrl(true, 100, 100);
 {% endcall %}
 
 {% call docs.alertWrap() %}
-图片缩略图只支持华北节点的应用，华东和北美节点不支持。
+国际版不支持图片缩略图。
 {% endcall %}
 {% endif %}
 {% endif %}


### PR DESCRIPTION
SDK 支持情况：

- [x] js
- [x] objc
- [x] python
- [x] php
- [x] swift、c# (没有提供 thumbnails)
- [x] java （6.0.3）