### PR TITLE
feat(storage): remove android setup guide

### DIFF
--- a/views/sdk_setup-android.md
+++ b/views/sdk_setup-android.md
@@ -1,3 +1,0 @@
-{% extends "./sdk_setup.tmpl" %}
-{% set platform_name = "Android" %}
-{% from "views/_data.njk" import libVersion as version %}


### PR DESCRIPTION
1. This has been merged into sdk_setup-java
2. Currently https://leancloud.cn/docs/sdk_setup-android.html is broken

Thanks wxjz for bringing this to our attention.
