### PR TITLE
Doc for all mini-app

### DIFF
--- a/views/miniapp-alipay.md
+++ b/views/miniapp-alipay.md
@@ -1,0 +1,2 @@
+{% extends "./miniapp.tmpl" %}
+{% set miniapp = "alipay" %}

--- a/views/miniapp-baidu.md
+++ b/views/miniapp-baidu.md
@@ -1,0 +1,2 @@
+{% extends "./miniapp.tmpl" %}
+{% set miniapp = "baidu" %}

--- a/views/miniapp-toutiao.md
+++ b/views/miniapp-toutiao.md
@@ -1,0 +1,2 @@
+{% extends "./miniapp.tmpl" %}
+{% set miniapp = "toutiao" %}

--- a/views/miniapp-wechat.md
+++ b/views/miniapp-wechat.md
@@ -1,0 +1,2 @@
+{% extends "./miniapp.tmpl" %}
+{% set miniapp = "wechat" %}

--- a/views/miniapp.tmpl
+++ b/views/miniapp.tmpl
@@ -1,14 +1,21 @@
 {#
-在支持多个平台的小程序后，提供专门的文档：miniapp.tmpl 来存放小程序相关的内容。
+在编写这篇文档之前，有关微信小程序内容安排在：weapp.md 这个文档中。
 更新微信小程序的文档时请同步两个文档中的内容。
 #}
 
 {% import "views/_data.njk" as data %}
 {% import "views/_helper.njk" as docs %}
+
+{% if miniapp === "wechat" %}
 # 在微信小程序（游戏）与 QQ 小程序（游戏）中使用 LeanCloud
 
 小程序是一个全新的跨平台移动应用平台，小游戏是小程序的一个类目，在小程序的基础上开放了游戏相关的 API。LeanCloud 为小程序提供一站式后端云服务，为你免去服务器维护、证书配置等繁琐的工作，大幅降低你的开发和运维成本。本文说明了如何在小程序与小游戏中使用 LeanCloud 提供的各项服务。
+{% endif %}
+{% if miniapp === "toutiao" %}
+# 在头条小程序中使用 LeanCloud
+{% endif %}
 
+{% if miniapp === "wechat" %}
 {{ docs.note('QQ 小程序兼容微信小程序的 API，概念与用法也相似。如果没有特殊说明，本文将不再区分微信小程序与 QQ 小程序。')}}
 
 ## Demo
@@ -23,25 +30,34 @@
 你可以通过微信或 QQ 扫描以下二维码进入 Demo。 Demo 的源码与运行说明请参考 [https://github.com/leancloud/leantodo-weapp](https://github.com/leancloud/leantodo-weapp)。
 
 <img src="images/leantodo-weapp-qr.jpg" alt="LeanTodo Weapp QR" width="250"> <img src="images/leantodo-qqapp-qr.png" alt="LeanTodo Weapp QR" width="250">
-
+{% endif %}
 
 ## 准备工作
+
 ### 创建应用
+{% if miniapp === "wechat" %}
 - 如果你还没有创建过 LeanCloud 应用，请登录 LeanCloud 控制台创建一个新应用。
 - 如果你还没有小程序帐号，请访问 [微信公众平台] 或 [QQ 小程序开放平台] 注册一个小程序帐号。如果你不需要进行真机调试可以跳过这一步。
 - 下载对应平台的小程序开发工具，按照指引创建一个新项目。
 
 [微信公众平台]: https://mp.weixin.qq.com
 [QQ 小程序开放平台]: https://q.qq.com
+{% endif %}
+{% if miniapp === "toutiao" %}
+TODO
+{% endif %}
 
 ### 配置域名白名单
 
-- 前往 [LeanCloud 控制台 > 设置 > 应用 Keys > 域名白名单][weapp-domains]，获取域名白名单（不同应用对应不同的域名）。
+- 前往 [LeanCloud 控制台 > 设置 > 应用 Keys > 域名白名单](https://leancloud.cn/dashboard/app.html?appid={{appid}}#/key)，获取域名白名单（不同应用对应不同的域名）。
+{% if miniapp === "wechat" %}
 - 登录 [微信公众平台] 或 [QQ 小程序开放平台]，前往 **设置 > 开发设置 > 服务器配置 > 「修改」** 链接，**增加**上述域名白名单中的域名。
 
-[weapp-domains]: https://leancloud.cn/dashboard/app.html?appid={{appid}}#/key
-
 如果你不需要进行真机调试可以暂时跳过这一步（可在开发者工具的 **详情** > **项目设置** 中勾选**不校验安全域名、TLS 版本以及 HTTPS 证书**）。
+{% endif %}
+{% if miniapp === "toutiao" %}
+TODO
+{% endif %}
 
 ### 安装与初始化 SDK
 
@@ -49,6 +65,7 @@
 
 安装存储 SDK 后即可在 `app.js` 中初始化应用：
 
+{% if miniapp === "wechat" %}
 ```javascript
 // 获取 AV 命名空间的方式根据不同的安装方式而异，这里假设是通过手动导入文件的方式安装的 SDK
 const AV = require('./libs/av-core-min.js');
@@ -62,13 +79,18 @@ AV.init({
   serverURLs: "https://xxx.example.com",
 });
 ```
+{% endif %}
+{% if miniapp === "toutiao" %}
+TODO
+{% endif %}
 
 要使用 LeanCloud 的即时通讯服务实现聊天等功能，需要使用 LeanCloud 即时通讯 SDK。即时通讯 SDK 是与存储 SDK 独立的 SDK，我们在单独的 [即时通讯](#即时通讯) 章节介绍其安装与初始化的步骤。
 
-
 ## 结构化对象存储
+
 所有的结构化对象存储 API 都能正常使用，详细的用法请参考 [JavaScript 数据存储开发指南](leanstorage_guide-js.html)。
 
+{% if miniapp === "wechat" %}
 ### 数据绑定
 
 `AV.Object` 实例是一些携带很多信息与方法的对象，而小程序的存放渲染用数据的 `data` 字段需要的是 JSON 类型的数据，因此我们需要将 `AV.Object` 实例处理为 JSON 数据后再设置给 `data`。
@@ -167,10 +189,11 @@ Page({
 ```
 
 {{ docs.note("你可能会在某些过时的文档或者 Demo 中看到直接使用 `this.setData()` 将 `AV.Object` 对象设置为当前页面的 data 的用法。我们 **不再推荐这种用法**。这是 SDK 针对小程序做的特殊「优化」，利用了小程序渲染机制中的一个未定义行为，目前已知在使用了自定义组件（`usingComponents`）时这种用法会失效。") }}
-
+{% endif %}
 
 ## 文件存储
 
+{% if miniapp === "wechat" %}
 在小程序中，可以将用户相册或拍照得到的图片上传到 LeanCloud 服务器进行保存。首先通过 `wx.chooseImage` 方法选择或拍摄照片，得到本地临时文件的路径，然后按照下面的方法构造一个 `AV.File` 将其上传到 LeanCloud：
 
 ```javascript
@@ -199,6 +222,10 @@ wx.chooseImage({
 上传成功后可以通过 `file.url()` 方法得到服务端的图片 url。
 
 关于文件存储更详细的用法请参考 [JavaScript 数据存储开发指南 · 文件](leanstorage_guide-js.html#文件)。
+{% endif %}
+{% if miniapp === "toutiao" %}
+TODO
+{% endif %}
 
 ## 用户系统
 
@@ -213,15 +240,32 @@ SDK 提供了一系列小程序特有的用户相关的 API，适用于不同的
 
 以上 API 均使用微信 Adapters 的 `AuthInfo` 进行登录。`AuthInfo` 可通过 Adapters 的 `getAuthInfo` 函数获取。若未提供 `AuthInfo` ，API 会使用默认参数调用 `getAuthInfo` 函数自动获取。
 
-下面我们以微信平台为例讨论不同场景下的使用方式。
+`getAuthInfo` 支持传入一个 `object` 来配置 Adapters 如何调用小程序的登录 API ，以下是配置支持的参数及其默认值：
+
+{% if miniapp === "wechat" %}
+|key|类型|默认值|说明|
+|---|---|-----|---|
+|`preferUnionId`|`boolean`|`false`|如果可以自动获取 unionid 则使用 unionid 登录
+|`platform`|`string`|`weixin`|unionid 对应的 platform 字符串
+|`asMainAccount`|`boolean`|`false`|是否把当前平台的鉴权信息作为主账号来使用
+{% endif %}
+{% if miniapp === "toutiao" %}
+|key|类型|默认值|说明|
+|---|---|-----|---|
+|`force`|`boolean`|`false`|未登录时, 是否强制调起登录框
+{% endif %}
+
+下面我们讨论不同场景下的使用方式。
 
 ### 一键登录
+
+{% if miniapp === "wechat" %}
 LeanCloud 的用户系统支持一键使用微信用户身份登录。要使用一键登录功能，需要先设置小程序的 AppID 与 AppSecret：
 
 1. 登录 [微信公众平台](https://mp.weixin.qq.com)，在 **设置** > **开发设置** 中获得 AppID 与 AppSecret。
 2. 前往 LeanCloud 控制台 > 存储 > 用户 > 设置 > 第三方集成，启用「微信小程序」后填写 AppID 与 AppSecret。
 
-这样你就可以在应用中使用 `AV.User.loginWithMiniApp()` 方法来使用当前用户身份登录了。
+这样你就可以在应用中使用 `AV.User.loginMiniApp()` 方法来使用当前用户身份登录了。
 
 ```javascript
 AV.User.loginWithMiniApp().then(user => {
@@ -242,11 +286,16 @@ AV.User.loginWithMiniApp().then(user => {
   }
 }
 ```
+{% endif %}
+{% if miniapp === "toutiao" %}
+TODO
+{% endif %}
 
 如果用户是第一次使用此应用，调用登录 API 会创建一个新的用户，你可以在 控制台 > **存储** 中的 `_User` 表中看到该用户的信息，如果用户曾经使用该方式登录过此应用（存在对应 `openid` 的用户），再次调用登录 API 会返回同一个用户。
 
 用户的登录状态会保存在客户端中，可以使用 `AV.User.current()` 方法来获取当前登录的用户，下面的例子展示了如何为登录用户保存额外的信息：
 
+{% if miniapp === "wechat" %}
 ```javascript
 // 假设已经通过 AV.User.loginWithMiniApp() 登录
 // 获得当前登录用户
@@ -266,7 +315,12 @@ wx.getUserInfo({
 `authData` 默认只有对应用户可见，开发者可以使用 masterKey 在云引擎中获取该用户的 `openid` 与 `session_key` 进行支付、推送等操作。详情的示例请参考 [支付](#支付)。
 
 {{ docs.note("小程序的登录态（`session_key`）存在有效期，可以通过 [`wx.checkSession()`](https://developers.weixin.qq.com/miniprogram/dev/api/wx.checkSession.html) 方法检测当前用户登录态是否有效，失效后可以通过调用 `AV.User.loginWithMiniApp()` 重新登录。") }}
+{% endif %}
+{% if miniapp === "toutiao" %}
+TODO
+{% endif %}
 
+{% if miniapp === "wechat" %}
 ### 使用 unionid
 
 微信开放平台使用 [unionid](https://developers.weixin.qq.com/miniprogram/dev/framework/open-ability/union-id.html) 来区分用户的唯一性，也就是说同一个微信开放平台帐号下的移动应用、网站应用和公众帐号（包括小程序），用户的 unionid 都是同一个，而 openid 会是多个。如果你想要实现多个小程序之间，或者小程序与使用微信开放平台登录的应用之间共享用户系统的话，则需要使用 unionid 登录。
@@ -410,6 +464,7 @@ adapters.getAuthInfo().then(authInfo => {
   return user.associateWithMiniApp(authInfo);
 });
 ```
+{% endif %}
 
 ### 启用其他登录方式
 上述的登录 API 对接的是小程序的用户系统，所以使用这些 API 创建的用户无法直接在小程序之外的平台上登录。如果需要使用 LeanCloud 用户系统提供的其他登录方式，如用手机号验证码登录、邮箱密码登录等，在小程序登录后设置对应的用户属性即可：
@@ -433,6 +488,7 @@ AV.User.loginWithMiniApp().then(user => {
 {{ docs.note("验证手机号码功能要求在「控制台 > 存储 > 用户 > 设置」中启用「用户注册时，向注册手机号码发送验证短信」。") }}
 
 ### 绑定现有用户
+
 如果你的应用已经在使用 LeanCloud 的用户系统，或者用户已经通过其他方式注册了你的应用（比如在 Web 端通过用户名密码注册），可以通过在小程序中调用 `AV.User#associateWithMiniApp()` 来关联已有的账户：
 
 ```javascript
@@ -452,6 +508,7 @@ AV.User.logIn('username', 'password').then(user => {
 
 安装 SDK 后即可在 `app.js` 中初始化应用：
 
+{% if miniapp === "wechat" %}
 ```javascript
 // Realtime 类获取的方式根据不同的安装方式而异，这里假设是通过手动导入文件的方式安装的 SDK
 const { Realtime, setAdapters } = require('./libs/im.min.js');
@@ -465,9 +522,14 @@ const realtime = new Realtime({
   serverURLs: "https://xxx.example.com",
 });
 ```
+{% endif %}
+{% if miniapp === "toutiao" %}
+TODO
+{% endif %}
 
 需要特别注意的是，小程序对 WebSocket 连接的数量是有限制的，因此推荐的用法是初始化 `Realtime` 一次，挂载到全局的 App 实例上，然后在所有需要的时候都使用这个 `Realtime` 实例。
 
+{% if miniapp === "wechat" %}
 ```js
 // app.js
 const { Realtime, setAdapters } = require('./libs/im.min.js');
@@ -488,6 +550,10 @@ App({
 // some-page.js
 const realtime = getApp().realtime;
 ```
+{% endif %}
+{% if miniapp === "toutiao" %}
+TODO
+{% endif %}
 
 即时通讯 SDK 的详细用法请参考 [即时通讯开发指南](realtime_v2.html)。
 
@@ -526,10 +592,13 @@ const realtime = getApp().realtime;
 
 富媒体消息的用法请参考 [即时通讯开发指南 - 富媒体消息](realtime-guide-beginner.html#文本之外的聊天消息)。
 
+{% if miniapp === "wechat" %}
 ### 数据绑定
 
 使用即时通讯 SDK，一个常见的需求是将 `Conversation` 与 `Message` 类型的数据绑定到视图层进行渲染。这里会遇到一些与结构化数据存储 SDK 一样的问题，其解决方案与最佳实践请参考结构化数据存储的 [数据绑定](#数据绑定) 章节（`Conversation` 与 `Message` 都实现了 `#toJSON` 方法，上文中介绍的 `jsonify` 方法同样适用于`Conversation` 与 `Message` 实例）。
+{% endif %}
 
+{% if miniapp === "wechat" %}
 ## 支付
 
 {{ docs.note('利用云引擎服务，我们能轻松的接入各类平台的支付功能。在这里我们以微信小程序中使用微信支付作为示例。')}}
@@ -623,6 +692,7 @@ AV.Cloud.run('order').then((data) => {
 客户端的示例代码参见 [Demo](https://github.com/leancloud/leantodo-weapp) 打赏功能。参考文档：
 
 * [小程序客户端发起支付 API](https://mp.weixin.qq.com/debug/wxadoc/dev/api/api-pay.html)
+{% endif %}
 
 ## FAQ
 

--- a/views/miniapp.tmpl
+++ b/views/miniapp.tmpl
@@ -46,6 +46,9 @@
 {% if miniapp === "toutiao" %}
 TODO
 {% endif %}
+{% if miniapp === "baidu" %}
+TODO
+{% endif %}
 
 ### 配置域名白名单
 
@@ -56,6 +59,9 @@ TODO
 如果你不需要进行真机调试可以暂时跳过这一步（可在开发者工具的 **详情** > **项目设置** 中勾选**不校验安全域名、TLS 版本以及 HTTPS 证书**）。
 {% endif %}
 {% if miniapp === "toutiao" %}
+TODO
+{% endif %}
+{% if miniapp === "baidu" %}
 TODO
 {% endif %}
 
@@ -81,6 +87,9 @@ AV.init({
 ```
 {% endif %}
 {% if miniapp === "toutiao" %}
+TODO
+{% endif %}
+{% if miniapp === "baidu" %}
 TODO
 {% endif %}
 
@@ -226,6 +235,9 @@ wx.chooseImage({
 {% if miniapp === "toutiao" %}
 TODO
 {% endif %}
+{% if miniapp === "baidu" %}
+TODO
+{% endif %}
 
 ## 用户系统
 
@@ -253,6 +265,11 @@ SDK 提供了一系列小程序特有的用户相关的 API，适用于不同的
 |key|类型|默认值|说明|
 |---|---|-----|---|
 |`force`|`boolean`|`false`|未登录时, 是否强制调起登录框
+{% endif %}
+{% if miniapp === "baidu" %}
+|key|类型|默认值|说明|
+|---|---|-----|---|
+|`platform`|`string`|`baidu`|unionid 对应的 platform 字符串
 {% endif %}
 
 下面我们讨论不同场景下的使用方式。
@@ -290,6 +307,9 @@ AV.User.loginWithMiniApp().then(user => {
 {% if miniapp === "toutiao" %}
 TODO
 {% endif %}
+{% if miniapp === "baidu" %}
+TODO
+{% endif %}
 
 如果用户是第一次使用此应用，调用登录 API 会创建一个新的用户，你可以在 控制台 > **存储** 中的 `_User` 表中看到该用户的信息，如果用户曾经使用该方式登录过此应用（存在对应 `openid` 的用户），再次调用登录 API 会返回同一个用户。
 
@@ -317,6 +337,9 @@ wx.getUserInfo({
 {{ docs.note("小程序的登录态（`session_key`）存在有效期，可以通过 [`wx.checkSession()`](https://developers.weixin.qq.com/miniprogram/dev/api/wx.checkSession.html) 方法检测当前用户登录态是否有效，失效后可以通过调用 `AV.User.loginWithMiniApp()` 重新登录。") }}
 {% endif %}
 {% if miniapp === "toutiao" %}
+TODO
+{% endif %}
+{% if miniapp === "baidu" %}
 TODO
 {% endif %}
 
@@ -526,6 +549,9 @@ const realtime = new Realtime({
 {% if miniapp === "toutiao" %}
 TODO
 {% endif %}
+{% if miniapp === "baidu" %}
+TODO
+{% endif %}
 
 需要特别注意的是，小程序对 WebSocket 连接的数量是有限制的，因此推荐的用法是初始化 `Realtime` 一次，挂载到全局的 App 实例上，然后在所有需要的时候都使用这个 `Realtime` 实例。
 
@@ -552,6 +578,9 @@ const realtime = getApp().realtime;
 ```
 {% endif %}
 {% if miniapp === "toutiao" %}
+TODO
+{% endif %}
+{% if miniapp === "baidu" %}
 TODO
 {% endif %}
 

--- a/views/miniapp.tmpl
+++ b/views/miniapp.tmpl
@@ -10,8 +10,11 @@
 # 在微信小程序（游戏）与 QQ 小程序（游戏）中使用 LeanCloud
 
 小程序是一个全新的跨平台移动应用平台，小游戏是小程序的一个类目，在小程序的基础上开放了游戏相关的 API。LeanCloud 为小程序提供一站式后端云服务，为你免去服务器维护、证书配置等繁琐的工作，大幅降低你的开发和运维成本。本文说明了如何在小程序与小游戏中使用 LeanCloud 提供的各项服务。
-{% endif %}
-{% if miniapp === "toutiao" %}
+{% elif miniapp === "alipay" %}
+# 在支付宝小程序中使用 LeanCloud
+{% elif miniapp === "baidu" %}
+# 在百度小程序中使用 LeanCloud
+{% elif miniapp === "toutiao" %}
 # 在头条小程序中使用 LeanCloud
 {% endif %}
 
@@ -32,6 +35,7 @@
 <img src="images/leantodo-weapp-qr.jpg" alt="LeanTodo Weapp QR" width="250"> <img src="images/leantodo-qqapp-qr.png" alt="LeanTodo Weapp QR" width="250">
 {% endif %}
 
+{% if miniapp === "wechat" %}  {# wechat-only-begin #}
 ## 准备工作
 
 ### 创建应用
@@ -43,12 +47,6 @@
 [微信公众平台]: https://mp.weixin.qq.com
 [QQ 小程序开放平台]: https://q.qq.com
 {% endif %}
-{% if miniapp === "toutiao" %}
-TODO
-{% endif %}
-{% if miniapp === "baidu" %}
-TODO
-{% endif %}
 
 ### 配置域名白名单
 
@@ -57,12 +55,6 @@ TODO
 - 登录 [微信公众平台] 或 [QQ 小程序开放平台]，前往 **设置 > 开发设置 > 服务器配置 > 「修改」** 链接，**增加**上述域名白名单中的域名。
 
 如果你不需要进行真机调试可以暂时跳过这一步（可在开发者工具的 **详情** > **项目设置** 中勾选**不校验安全域名、TLS 版本以及 HTTPS 证书**）。
-{% endif %}
-{% if miniapp === "toutiao" %}
-TODO
-{% endif %}
-{% if miniapp === "baidu" %}
-TODO
 {% endif %}
 
 ### 安装与初始化 SDK
@@ -85,12 +77,6 @@ AV.init({
   serverURLs: "https://xxx.example.com",
 });
 ```
-{% endif %}
-{% if miniapp === "toutiao" %}
-TODO
-{% endif %}
-{% if miniapp === "baidu" %}
-TODO
 {% endif %}
 
 要使用 LeanCloud 的即时通讯服务实现聊天等功能，需要使用 LeanCloud 即时通讯 SDK。即时通讯 SDK 是与存储 SDK 独立的 SDK，我们在单独的 [即时通讯](#即时通讯) 章节介绍其安装与初始化的步骤。
@@ -232,12 +218,7 @@ wx.chooseImage({
 
 关于文件存储更详细的用法请参考 [JavaScript 数据存储开发指南 · 文件](leanstorage_guide-js.html#文件)。
 {% endif %}
-{% if miniapp === "toutiao" %}
-TODO
-{% endif %}
-{% if miniapp === "baidu" %}
-TODO
-{% endif %}
+{% endif %} {# wechat-only-end #}
 
 ## 用户系统
 
@@ -260,13 +241,15 @@ SDK 提供了一系列小程序特有的用户相关的 API，适用于不同的
 |`preferUnionId`|`boolean`|`false`|如果可以自动获取 unionid 则使用 unionid 登录
 |`platform`|`string`|`weixin`|unionid 对应的 platform 字符串
 |`asMainAccount`|`boolean`|`false`|是否把当前平台的鉴权信息作为主账号来使用
-{% endif %}
-{% if miniapp === "toutiao" %}
+{% elif miniapp === "alipay" %}
+|key|类型|默认值|说明|
+|---|---|-----|---|
+|`scopes`|`string` / `Array`|`auth_base`|授权类型，默认 auth_base。支持 auth_base（静默授权）/ auth_user（主动授权）/ auth_zhima （获取用户芝麻信息）
+{% elif miniapp === "toutiao" %}
 |key|类型|默认值|说明|
 |---|---|-----|---|
 |`force`|`boolean`|`false`|未登录时, 是否强制调起登录框
-{% endif %}
-{% if miniapp === "baidu" %}
+{% elif miniapp === "baidu" %}
 |key|类型|默认值|说明|
 |---|---|-----|---|
 |`platform`|`string`|`baidu`|unionid 对应的 platform 字符串
@@ -303,12 +286,88 @@ AV.User.loginWithMiniApp().then(user => {
   }
 }
 ```
-{% endif %}
-{% if miniapp === "toutiao" %}
-TODO
-{% endif %}
-{% if miniapp === "baidu" %}
-TODO
+{% elif miniapp === "alipay" %}
+LeanCloud 的用户系统支持一键使用支付宝的用户身份登录。要使用一键登录功能，需要先设置小程序的应用 ID 、应用私钥和支付宝公钥（注意不是应用公钥）：
+
+1. 按照[设置接口加签方式](https://opendocs.alipay.com/open/291/105971/)中的步骤生成应用私钥和公钥。
+2. 进入[支付宝开放平台](https://mini.open.alipay.com/channel/miniIndex.htm)并打开对应的应用，在应用的开发设置页面进行**接口加签方式**设置，填写应用公钥。
+3. 前往 LeanCloud 控制台 > 存储 > 用户 > 设置 > 第三方集成，启用「支付宝小程序」后填写应用 ID 、应用私钥和支付宝公钥。
+
+这样你就可以在应用中使用 `AV.User.loginWithMiniApp()` 方法来使用当前用户身份登录了。
+
+```js
+AV.User.loginWithMiniApp().then(user => {
+  // user 为当前登录用户
+})
+```
+
+使用一键登录方式登录时，LeanCloud 会将该用户的 `user_id` 与 `access_token` 等信息保存在对应的 `user.authData.lc_alipay` 属性中，你可以在控制台的 `_User` 表中看到：
+
+```json
+{
+  "authData": {
+    "lc_alipay": {
+      "access_token": "...",
+      "alipay_user_id": "...",
+      "expires_in": 31536000,
+      "re_expires_in": 31536000,
+      "refresh_token": "...",
+      "user_id": "..."
+    }
+  }
+}
+```
+{% elif miniapp === "baidu" %}
+LeanCloud 的用户系统支持一键使用百度用户的身份登录。要使用一键登录功能，需要先设置小程序的 App Key 和 App Secret ：
+
+1. 登录百度小程序[开发者平台](https://smartprogram.baidu.com/developer/index.html)，在 **开发管理** > **设置** > **开发设置** 中获得 App Key 与 App Secret 。
+2. 前往 LeanCloud 控制台 > 存储 > 用户 > 设置 > 第三方集成，启用「百度小程序」后填写 App Key 与 App Secret。
+
+这样你就可以在应用中使用 `AV.User.loginWithMiniApp()` 方法来使用当前用户身份登录了。
+
+```js
+AV.User.loginWithMiniApp().then(user => {
+  // user 为当前登录用户
+})
+```
+
+使用一键登录方式登录时，LeanCloud 会将该用户的小程序 `openid` 与 `session_key` 等信息保存在对应的 `user.authData.lc_baidu` 属性中，你可以在控制台的 `_User` 表中看到：
+
+```json
+{
+  "authData": {
+    "lc_baidu": {
+      "openid": "...",
+      "session_key": "..."
+    }
+  }
+}
+```
+{% elif miniapp === "toutiao" %}
+LeanCloud 的用户系统支持一键使用头条用户的身份登录。要使用一键登录功能，需要先设置小程序的 AppID 和 AppSecret ：
+
+1. 登录字节跳动[小程序开发者平台](https://microapp.bytedance.com/)并选择要关联的小程序，在 **开发管理** > **开发设置** 中获得 AppID 与 AppSecret 。
+2. 前往 LeanCloud 控制台 > 存储 > 用户 > 设置 > 第三方集成，启用「字节跳动小程序」后填写 AppID 与 AppSecret。
+
+这样你就可以在应用中使用 `AV.User.loginWithMiniApp()` 方法来使用当前用户身份登录了。
+
+```js
+AV.User.loginWithMiniApp().then(user => {
+  // user 为当前登录用户
+})
+```
+
+使用一键登录方式登录时，LeanCloud 会将该用户的小程序 `openid` 与 `session_key` 等信息保存在对应的 `user.authData.lc_tt` 属性中，你可以在控制台的 `_User` 表中看到：
+
+```json
+{
+  "lc_tt": {
+    "anonymousCode": "...",
+    "openid": "...",
+    "session_key": "..."
+  }
+}
+```
 {% endif %}
 
 如果用户是第一次使用此应用，调用登录 API 会创建一个新的用户，你可以在 控制台 > **存储** 中的 `_User` 表中看到该用户的信息，如果用户曾经使用该方式登录过此应用（存在对应 `openid` 的用户），再次调用登录 API 会返回同一个用户。
@@ -335,12 +394,58 @@ wx.getUserInfo({
 `authData` 默认只有对应用户可见，开发者可以使用 masterKey 在云引擎中获取该用户的 `openid` 与 `session_key` 进行支付、推送等操作。详情的示例请参考 [支付](#支付)。
 
 {{ docs.note("小程序的登录态（`session_key`）存在有效期，可以通过 [`wx.checkSession()`](https://developers.weixin.qq.com/miniprogram/dev/api/wx.checkSession.html) 方法检测当前用户登录态是否有效，失效后可以通过调用 `AV.User.loginWithMiniApp()` 重新登录。") }}
-{% endif %}
-{% if miniapp === "toutiao" %}
-TODO
-{% endif %}
-{% if miniapp === "baidu" %}
-TODO
+{% elif miniapp === "alipay" %}
+```js
+// 假设已经通过 AV.User.loginWithMiniApp() 登录
+// 获得当前登录用户
+const user = AV.User.current();
+// 调用小程序 API，得到用户信息
+my.getOpenUserInfo({
+  success: (res) => {
+    const userInfo = JSON.parse(res.response).response;
+    // 更新当前用户的信息
+    user.set(userInfo).save().then(user => {
+      // 成功，此时可在控制台中看到更新后的用户信息
+    }).catch(console.error)
+  }
+});
+```
+
+`authData` 默认只有对应用户可见，开发者可以使用 masterKey 在云引擎中获取该用户的 `user_id` 、 `access_token` 等信息。
+{% elif miniapp === "baidu" %}
+```js
+// 假设已经通过 AV.User.loginWithMiniApp() 登录
+// 获得当前登录用户
+const user = AV.User.current();
+// 调用小程序 API，得到用户信息
+swan.getUserInfo({
+  success: ({userInfo}) => {
+    // 更新当前用户的信息
+    user.set(userInfo).save().then(user => {
+      // 成功，此时可在控制台中看到更新后的用户信息
+    }).catch(console.error);
+  }
+});
+```
+
+`authData` 默认只有对应用户可见，开发者可以使用 masterKey 在云引擎中获取该用户的 `openid` 与 `session_key` 。
+{% elif miniapp === "toutiao" %}
+```js
+// 假设已经通过 AV.User.loginWithMiniApp() 登录
+// 获得当前登录用户
+const user = AV.User.current();
+// 调用小程序 API，得到用户信息
+tt.getUserInfo({
+  success: ({userInfo}) => {
+    // 更新当前用户的信息
+    user.set(userInfo).save().then(user => {
+      // 成功，此时可在控制台中看到更新后的用户信息
+    }).catch(console.error);
+  }
+});
+```
+
+`authData` 默认只有对应用户可见，开发者可以使用 masterKey 在云引擎中获取该用户的 `openid` 与 `session_key` 。
 {% endif %}
 
 {% if miniapp === "wechat" %}
@@ -522,6 +627,7 @@ AV.User.logIn('username', 'password').then(user => {
 }).catch(console.error);
 ```
 
+{% if miniapp === "wechat" %} {# wechat-only-begin #}
 ## 即时通讯
 
 要使用 LeanCloud 的即时通讯服务实现聊天等功能，需要使用 LeanCloud 即时通讯 SDK。
@@ -545,12 +651,6 @@ const realtime = new Realtime({
   serverURLs: "https://xxx.example.com",
 });
 ```
-{% endif %}
-{% if miniapp === "toutiao" %}
-TODO
-{% endif %}
-{% if miniapp === "baidu" %}
-TODO
 {% endif %}
 
 需要特别注意的是，小程序对 WebSocket 连接的数量是有限制的，因此推荐的用法是初始化 `Realtime` 一次，挂载到全局的 App 实例上，然后在所有需要的时候都使用这个 `Realtime` 实例。
@@ -576,12 +676,6 @@ App({
 // some-page.js
 const realtime = getApp().realtime;
 ```
-{% endif %}
-{% if miniapp === "toutiao" %}
-TODO
-{% endif %}
-{% if miniapp === "baidu" %}
-TODO
 {% endif %}
 
 即时通讯 SDK 的详细用法请参考 [即时通讯开发指南](realtime_v2.html)。
@@ -722,6 +816,7 @@ AV.Cloud.run('order').then((data) => {
 
 * [小程序客户端发起支付 API](https://mp.weixin.qq.com/debug/wxadoc/dev/api/api-pay.html)
 {% endif %}
+{% endif %} {# wechat-only-end #}
 
 ## FAQ
 

--- a/views/weapp.md
+++ b/views/weapp.md
@@ -213,6 +213,14 @@ SDK 提供了一系列小程序特有的用户相关的 API，适用于不同的
 
 以上 API 均使用微信 Adapters 的 `AuthInfo` 进行登录。`AuthInfo` 可通过 Adapters 的 `getAuthInfo` 函数获取。若未提供 `AuthInfo` ，API 会使用默认参数调用 `getAuthInfo` 函数自动获取。
 
+`getAuthInfo` 支持传入一个 `object` 来配置 Adapters 如何调用小程序的登录 API ，以下是配置支持的参数及其默认值：
+
+|key|类型|默认值|说明|
+|---|---|-----|---|
+|`preferUnionId`|`boolean`|`false`|如果可以自动获取 unionid 则使用 unionid 登录
+|`platform`|`string`|`weixin`|unionid 对应的 platform 字符串
+|`asMainAccount`|`boolean`|`false`|是否把当前平台的鉴权信息作为主账号来使用
+
 下面我们以微信平台为例讨论不同场景下的使用方式。
 
 ### 一键登录


### PR DESCRIPTION
需要一个文档介绍所有平台小程序的用法，所以新添加了一个 `mini-app.md` 来做这件事。

目前把 `weapp.md` 下用户系统相关的内容拷贝过来，并添加了头条小程序相关的内容。如果这个方案可行，后续将逐步完善其他平台小程序相应的内容。

---

经过讨论，[方案2](https://github.com/leancloud/docs#%E5%A4%9A%E8%AF%AD%E8%A8%80%E5%A4%9A%E5%B9%B3%E5%8F%B0%E5%85%B1%E4%BA%AB%E6%96%87%E6%A1%88%E8%A7%A3%E5%86%B3%E6%96%B9%E6%A1%88-2---%E5%86%85%E5%AE%B9%E9%9B%86%E4%B8%AD%E5%88%B0%E4%B8%80%E4%BB%BD-tmpl-%E6%96%87%E4%BB%B6%E6%AF%8F%E4%B8%AA%E8%AF%AD%E8%A8%80-md-%E6%96%87%E4%BB%B6%E4%BB%85%E4%BD%9C%E9%AA%A8%E6%9E%B6)比较适合解决这个需求。

进度：

- [x] 更新百度小程序的 `getAuthInfo` 说明
- [x] 更新头条小程序的 `getAuthInfo` 说明
- [x] 更新支付宝小程序的 `getAuthInfo` 说明

---
### 2020-08-04 更新
由于 API 已完成对各小程序平台一键登录的支持，SDK Adapters 也刚进行完新一轮的重构，准备向用户介绍「LeanCloud 对各小程序平台的支持」。

需要提供的各小程序平台的说明文档：
- ~~SDK 安装的方法（相关内容已合并）~~
- 一键登录功能的使用方法

本 PR 是为了提供一个独立的模板来存放所有小程序相关的文档，截至 d75726b626bfb29dcfacbc57bf61a394d443f071 只是完成了百度、头条小程序的一键登录 API `getAuthInfo` 的说明，由于更新小程序文档的优先级较低，所以一直处于搁置状态。

现在需要一个介绍各小程序平台「一键登录」功能的文档，遂决定将相关内容加入本 PR （miniapp.tmpl 模板），并隐藏未完成的部分（目前除微信小程序外，均只提供「用户系统」相关内容），将来对小程序文档的更新可继续追加至 miniapp.tmpl 中。