### PR TITLE
fix(engine): update php version

### DIFF
--- a/views/leanengine_webhosting_guide.tmpl
+++ b/views/leanengine_webhosting_guide.tmpl
@@ -169,7 +169,7 @@ LeanEngine PHP 项目必须有 `$PROJECT_DIR/public/index.php` 文件，该文�
 
 ```json
 "require": {
-  "php": "7.0"
+  "php": "7.4.x"
 }
 ```
 


### PR DESCRIPTION
php 7.0 support ended on 3 December 2018.
