### PR TITLE
fix(java): callRPCWithCacheInBackground type error

### DIFF
--- a/views/leanengine_cloudfunction_guide.tmpl
+++ b/views/leanengine_cloudfunction_guide.tmpl
@@ -668,7 +668,7 @@ cloud.rpc('averageStars', movie='夏洛特烦恼')
 ```
 ```java
 // 构建参数
-Map<String, String> dicParameters = new HashMap<String, String>();
+Map<String, Object> dicParameters = new HashMap<>();
 dicParameters.put("movie", "夏洛特烦恼");
 
 AVCloud.<AVObject>callRPCInBackground("averageStars", dicParameters).subscribe(new Observer<AVObject>() {


### PR DESCRIPTION
The type of `params` argument of callRPCWithCacheInBackground is
`@NotNull java.util.Map<String, Object>`,
which is incompatible with Map<String, String>
