### PR TITLE
feat: remove leanchat-android demo link

### DIFF
--- a/views/realtime-guide-systemconv.md
+++ b/views/realtime-guide-systemconv.md
@@ -81,8 +81,6 @@ Hook 也可以称为「钩子」，是一种特殊的消息处理机制，与 Wi
 
 ### Hook API 细节与使用场景详解
 
-示例应用 [LeanChat](https://github.com/leancloud/leanchat-android) 也用了云引擎 Hook 功能来自定义消息推送，通过解析上层消息协议获取消息类型和内容，以 `fromPeer` 得到发送者的名称，组装成 `pushMessage`，这样能使推送通知的用户体验更好。可参考 [leanchat-cloudcode 代码](https://github.com/leancloud/leanchat-cloudcode/blob/master/cloud.js)。
-
 与 `conversation` 相关的 hook 可以在应用签名之外增加额外的权限判断，控制对话是否允许被建立、某些用户是否允许被加入对话等。你可以用这一 hook 实现黑名单功能。
 
 #### `_messageReceived`

--- a/views/realtime_v2.md
+++ b/views/realtime_v2.md
@@ -72,7 +72,6 @@ LeanCloud 即时通讯服务提供的主要功能有：
 
 * Android 聊天应用：
   * [ChatKit，自带 UI 的聊天工具包](chatkit-android.html)
-  * [LeanChat Android 版](https://github.com/leancloud/leanchat-android)
 
 * JavaScript 聊天应用：
   * [LeanMessage Demo 网页版](https://github.com/leancloud/leanmessage-demo)


### PR DESCRIPTION
This demo is not maintained anymore:

- There is no leanchat-android repository under the leancloud organization.
- The latest commit of lzwjava/leanchat-android is on Sep. 5, 2015.

Thank 1063271662 for bringing this to our attention.
