### PR TITLE
feat: use curl instead of ping to test network

### DIFF
--- a/views/sdk_setup.tmpl
+++ b/views/sdk_setup.tmpl
@@ -1649,7 +1649,7 @@ LCLogger.setLevel(LCLogger.DebugLevel);
 首先，确认本地网络环境是可以访问 LeanCloud 服务器的，可以执行以下命令：
 
 ```sh
-ping "https://{{host}}/1.1/date"
+curl "https://{{host}}/1.1/date"
 ```
 
 `{{host}}` 为绑定的 API 自定义域名。

--- a/views/sdk_setup.tmpl
+++ b/views/sdk_setup.tmpl
@@ -1649,29 +1649,15 @@ LCLogger.setLevel(LCLogger.DebugLevel);
 首先，确认本地网络环境是可以访问 LeanCloud 服务器的，可以执行以下命令：
 
 ```sh
-ping "{{host}}"
+ping "https://{{host}}/1.1/date"
 ```
 
 `{{host}}` 为绑定的 API 自定义域名。
 
-如果当前网路正常将会得到如下响应：
+如果当前网路正常会返回当前时间：
 
-```sh
-PING api-ucloud.leancloud.cn (123.59.41.31): 56 data bytes
-64 bytes from 123.59.41.31: icmp_seq=0 ttl=51 time=9.032 ms
-64 bytes from 123.59.41.31: icmp_seq=1 ttl=51 time=7.290 ms
-64 bytes from 123.59.41.31: icmp_seq=2 ttl=51 time=8.131 ms
-64 bytes from 123.59.41.31: icmp_seq=3 ttl=51 time=9.689 ms
-64 bytes from 123.59.41.31: icmp_seq=4 ttl=51 time=6.559 ms
-64 bytes from 123.59.41.31: icmp_seq=5 ttl=51 time=8.665 ms
-64 bytes from 123.59.41.31: icmp_seq=6 ttl=51 time=8.041 ms
-64 bytes from 123.59.41.31: icmp_seq=7 ttl=51 time=8.203 ms
-64 bytes from 123.59.41.31: icmp_seq=8 ttl=51 time=6.288 ms
-64 bytes from 123.59.41.31: icmp_seq=9 ttl=51 time=7.938 ms
-
---- api-ucloud.leancloud.cn ping statistics ---
-10 packets transmitted, 10 packets received, 0.0% packet loss
-round-trip min/avg/max/stddev = 6.288/7.984/9.689/0.997 ms
+```json
+{"__type":"Date","iso":"2020-10-12T06:46:56.000Z"}
 ```
 
 {% if platform_name === "Objective-C" %}


### PR DESCRIPTION
Not all LeanCloud servers support ping.

see also #3707
