### PR TITLE
feat: apionlinetest is unavailable now

### DIFF
--- a/views/rest_api.md
+++ b/views/rest_api.md
@@ -20,8 +20,6 @@ REST API 可以让你用任何支持发送 HTTP 请求的设备来与 LeanCloud 
 
 ### 在线测试
 
-你可以使用 **控制台 > 帮助 > API 在线测试工具** 进行在线测试。该工具目前仅支持调试**中国节点**下的应用。
-
 为了方便测试 REST API，文档给出了 curl 命令示例，示例针对类 unix 平台（macOS、Linux 等）编写，直接粘贴至 Windows 平台 cmd.exe 很可能无法工作。
 例如，curl 命令示例中的 shell 换行符（`\`）在 cmd.exe 中是目录分隔符。
 Windows 平台建议使用 [Postman] 等客户端测试。

--- a/views/tool_tips.md
+++ b/views/tool_tips.md
@@ -10,7 +10,6 @@
 * 查询的时候如果想将关联 Pointer 类型带入查询结果，请使用 AV.Query 的 `includeKey` 方法指定字段名称。
 * 查询可以指定 skip 和 limit 做分页查询。
 * 你可以在 [错误码详解](error_code.html) 文档里找到所有的错误代码和信息解释。
-* 你可以使用 [API 在线测试工具](rest_api.md#在线测试) 在线测试我们提供的开放 [REST API](rest_api.html)。
 * 我们的用户账户系统都自动做了密码加密存储，基于 SHA-512 加密算法，使用随机生成的 salt 加密。
 * 我们提供短信服务，你可以使用短息服务发送手机验证码、手机登录验证码等。具体参考各 SDK 开发指南。
 * 我们提供了 iOS、Android、JavaScript、Unity3D 等平台的 SDK，进入 [SDK 下载页面](sdk_down.html)。


### PR DESCRIPTION
It is absent in new dashboard and old dashboard will be redirected
very soon.
