### PR TITLE
fix: simplify a JS ACL sample

### DIFF
--- a/views/acl-guide.md
+++ b/views/acl-guide.md
@@ -351,8 +351,7 @@ acl.setAccess([.write], allowed: true, forRoleName:"admin")
 acl.setRoleWriteAccess("admin", true);
 ```
 ```js
-const admin = new AV.Role('admin');
-acl.setRoleWriteAccess(admin, true);
+acl.setRoleWriteAccess('admin', true);
 ```
 ```python
 admin = leancloud.Role('admin')


### PR DESCRIPTION
The original sample throws as `AV.Role` requires ACL to init now.