### PR TITLE
fix push-rest-api url

### DIFF
--- a/templates/pages/index.html
+++ b/templates/pages/index.html
@@ -278,7 +278,7 @@ layout: index.swig
 
               <h3>REST</h3>
               <ul class="list-unstyled">
-                  <li><a href="push_guide.html#使用_REST_API_推送消息">消息推送 REST API</a></li>
+                  <li><a href="push-rest-api.html">推送 REST API 使用指南</a></li>
               </ul>
 
             </div>


### PR DESCRIPTION
现在文档没有推送 REST API 文档的入口了。
我把首页地址由链接： https://leancloud.cn/docs//push_guide.html#hash978195304  改成直接跳转到 REST API 文档：

![image](https://user-images.githubusercontent.com/11917002/120959983-8a53dc80-c78d-11eb-8a07-2eac8be106b3.png)
