### PR TITLE
fix: update demo url

### DIFF
--- a/custom/js/demo.js
+++ b/custom/js/demo.js
@@ -240,7 +240,7 @@ angular.module('app').controller('DemoCtrl', ['$http', '$scope', '$rootScope', '
         name: '猜拳游戏',
         desc: 'LeanCloud Client Engine 服务端（Node.js）示例',
         downPath: '',
-        mdPath: 'https://rpsgame.cn-e1.leanapp.cn/',
+        mdPath: 'https://github.com/leancloud/client-engine-nodejs-getting-started',
         type: 'typescript',
         qcloudShow: true
       }]


### PR DESCRIPTION
「猜拳游戏」原链接对应的应用并没有部署，因而点进去只会显示「应用无响应」，替换为 github 链接。