### PR TITLE
feat(js/im): typed messages plugin v4

### DIFF
--- a/views/realtime-faq.md
+++ b/views/realtime-faq.md
@@ -80,34 +80,6 @@ LeanCloud 即时通讯服务是完全独立的即时通讯业务抽象，专注�
 
 LeanCloud 云引擎提供了托管 Python 和 Node.js 运行的方式，开发者可以用这两种语言按照签名的算法实现签名，完全可以支持开发者的自定义权限控制。
 
-### JavaScript SDK 即时通信使用 `leancloud-storage/live-query` SDK，创建图片消息报类型错误:「`TypeError：file must be an AV.File`」。
- 
-
-这个问题是因为 typed-messages plugin 会从 'leancloud-storage' 中 import File，而用 webpack 打包时 'leancloud-storage' 与 'leancloud-storage/live-query' 对应的是两个不同的 bundle，所以拿到的 File 不是同一个 File。
-
-推荐的用法是直接使用 `leancloud-storage` 然后单独加载 LiveQuery 部分，需要在初始化 SDK 的时候进行如下配置： 
-
-```
-import { Realtime } from 'leancloud-realtime';
-import { LiveQueryPlugin } from 'leancloud-realtime-plugin-live-query';
-import { TypedMessagesPlugin } from 'leancloud-realtime-plugin-typed-messages';
-import AV from 'leancloud-storage';
-
-const realtime = new Realtime({
-  // appId, appKey,
-  plugins: [TypedMessagesPlugin, LiveQueryPlugin],
-});
-AV.init({
-  // appId, appKey,
-  realtime,
-});
-```
-对于同时使用 RTM 与 LiveQuery 的场景，这样处理还有一些好处：  
-
-* 减少重复的代码（因为 leancloud-storage/live-query 是可以独立运行的，这个 bundle 里包含了 RTM 的核心部分代码），大大减少最终 bundle 的体积。 
-
-* RTM 与 LiveQuery 共享一个长链接，减少用户的客户端开销。
-
 
 ### 即时通信服务中，有些消息类型及时性要求特别高，有些消息及时性要求不高。一个房间内的消息有没有优先级？
 

--- a/views/realtime-guide-beginner.md
+++ b/views/realtime-guide-beginner.md
@@ -1823,7 +1823,7 @@ LCIMImageMessage *message = [LCIMImageMessage messageWithText:@"萌妹子一枚"
 ```
 ```js
 var AV = require('leancloud-storage');
-var { ImageMessage } = require('leancloud-realtime-plugin-typed-messages');
+var { ImageMessage } = initPlugin(AV, IM);
 // 从网络链接直接构建一个图像消息
 var file = new AV.File.withURL('萌妹子', 'http://pic2.zhimg.com/6c10e6053c739ed0ce676a0aff15cf1c.gif');
 file.save().then(function() {
@@ -1916,7 +1916,7 @@ LCIMMessageManager.registerMessageHandler(LCIMImageMessage.class,
 ```
 ```js
 var { Event, TextMessage } = require('leancloud-realtime');
-var { ImageMessage } = require('leancloud-realtime-plugin-typed-messages');
+var { ImageMessage } = initPlugin(AV, IM);
 
 client.on(Event.MESSAGE, function messageEventHandler(message, conversation) {
    var file;
@@ -2014,7 +2014,7 @@ if (!error) {
 ```
 ```js
 var AV = require('leancloud-storage');
-var { AudioMessage } = require('leancloud-realtime-plugin-typed-messages');
+var { AudioMessage } = initPlugin(AV, IM);
 
 var fileUploadControl = $('#musicFileUpload')[0];
 var file = new AV.File('忐忑.mp3', fileUploadControl.files[0]);
@@ -2093,7 +2093,7 @@ LCIMAudioMessage *message = [LCIMAudioMessage messageWithText:@"来自苹果发�
 ```
 ```js
 var AV = require('leancloud-storage');
-var { AudioMessage } = require('leancloud-realtime-plugin-typed-messages');
+var { AudioMessage } = initPlugin(AV, IM);
 
 var file = new AV.File.withURL('apple.aac', 'https://some.website.com/apple.aac');
 file.save().then(function() {
@@ -2169,7 +2169,7 @@ LCIMLocationMessage *message = [LCIMLocationMessage messageWithText:@"蛋糕店�
 ```
 ```js
 var AV = require('leancloud-storage');
-var { LocationMessage } = require('leancloud-realtime-plugin-typed-messages');
+var { LocationMessage } = initPlugin(AV, IM);
 
 var location = new AV.GeoPoint(31.3753285, 120.9664658);
 var message = new LocationMessage(location);
@@ -2308,7 +2308,7 @@ C# SDK 也是通过类似 `OnMessage` 事件回调来通知新消息的：
 ```js
 // 在初始化 Realtime 时，需加载 TypedMessagesPlugin
 var { Event, TextMessage } = require('leancloud-realtime');
-var { FileMessage, ImageMessage, AudioMessage, VideoMessage, LocationMessage } = require('leancloud-realtime-plugin-typed-messages');
+var { FileMessage, ImageMessage, AudioMessage, VideoMessage, LocationMessage } = initPlugin(AV, IM);
 // 注册 MESSAGE 事件的 handler
 client.on(Event.MESSAGE, function messageEventHandler(message, conversation) {
   // 请按自己需求改写

--- a/views/sdk_setup.tmpl
+++ b/views/sdk_setup.tmpl
@@ -336,7 +336,7 @@ Node.js 中 SDK 的安装与引用也是通过包管理工具 npm，请参考 [n
 
 前往 [即时通讯 SDK 下载页](https://releases.leanapp.cn/#/leancloud/js-realtime-sdk/releases)，下载最新版本的 `im.min.js`，移动到 `libs` 目录，并将文件重命名为 `leancloud-realtime.js`。
 
-下载 [`typed-messages.min.js`](https://code.bdstatic.com/npm/leancloud-realtime-plugin-typed-messages@4.0.2/dist/typed-messages.min.js)，移动到 `libs` 目录。必须保证<strong>三个文件在同一目录中</strong>。
+下载 [`typed-messages.min.js`](https://code.bdstatic.com/npm/leancloud-realtime-plugin-typed-messages@4.0.2/dist/typed-messages.min.js)，移动到 `libs` 目录。
 {{ docs.langSpecEnd('即时通讯（含富媒体消息）') }}
 
 前往 [微信小程序 Adapters 下载页](https://unpkg.com/browse/@leancloud/platform-adapters-weapp/lib/)，下载最新版本的 `index.js`，移动到 `libs` 目录，并将文件重命名为 `leancloud-adapters-weapp.js`。

--- a/views/sdk_setup.tmpl
+++ b/views/sdk_setup.tmpl
@@ -273,7 +273,7 @@ const { Realtime } = require('leancloud-realtime/es-latest');
 ```即时通讯（含富媒体消息）
 <script src="//code.bdstatic.com/npm/leancloud-storage@{{jssdkversion}}/dist/av-min.js"></script>
 <script src="//code.bdstatic.com/npm/leancloud-realtime@{{jsimsdkversion}}/dist/im-browser.min.js"></script>
-<script src="//code.bdstatic.com/npm/leancloud-realtime-plugin-typed-messages@3.1.0/dist/typed-messages.min.js"></script>
+<script src="//code.bdstatic.com/npm/leancloud-realtime-plugin-typed-messages@4.0.2/dist/typed-messages.min.js"></script>
 ```
 
 通过这种方式引入的 SDK 可以通过全局变量 `AV` 获得引用：
@@ -336,7 +336,7 @@ Node.js 中 SDK 的安装与引用也是通过包管理工具 npm，请参考 [n
 
 前往 [即时通讯 SDK 下载页](https://releases.leanapp.cn/#/leancloud/js-realtime-sdk/releases)，下载最新版本的 `im.min.js`，移动到 `libs` 目录，并将文件重命名为 `leancloud-realtime.js`。
 
-下载 [`typed-messages.min.js`](https://code.bdstatic.com/npm/leancloud-realtime-plugin-typed-messages@4/dist/typed-messages.min.js)，移动到 `libs` 目录。必须保证<strong>三个文件在同一目录中</strong>。
+下载 [`typed-messages.min.js`](https://code.bdstatic.com/npm/leancloud-realtime-plugin-typed-messages@4.0.2/dist/typed-messages.min.js)，移动到 `libs` 目录。必须保证<strong>三个文件在同一目录中</strong>。
 {{ docs.langSpecEnd('即时通讯（含富媒体消息）') }}
 
 前往 [微信小程序 Adapters 下载页](https://unpkg.com/browse/@leancloud/platform-adapters-weapp/lib/)，下载最新版本的 `index.js`，移动到 `libs` 目录，并将文件重命名为 `leancloud-adapters-weapp.js`。
@@ -531,7 +531,7 @@ setAdapters(adapters);    // 为即时通讯 SDK 设置 adapters
 
 前往 [即时通讯 SDK 下载页](https://releases.leanapp.cn/#/leancloud/js-realtime-sdk/releases)，下载最新版本的 `im.min.js`，移动到 `libs` 目录，并将文件重命名为 `leancloud-realtime.js`。
 
-下载 [`typed-messages.min.js`](https://code.bdstatic.com/npm/leancloud-realtime-plugin-typed-messages@4/dist/typed-messages.min.js)，移动到 `libs` 目录。必须保证<strong>三个文件在同一目录中</strong>。
+下载 [`typed-messages.min.js`](https://code.bdstatic.com/npm/leancloud-realtime-plugin-typed-messages@4.0.2/dist/typed-messages.min.js)，移动到 `libs` 目录。必须保证<strong>三个文件在同一目录中</strong>。
 {{ docs.langSpecEnd('即时通讯（含富媒体消息）') }}
 
 前往 [字节跳动小程序 Adapters 下载页](https://code.bdstatic.com/npm/@leancloud/platform-adapters-toutiao@1.4.1/lib/index.js)，下载最新版本的 `index.js`，移动到 `libs` 目录，并将文件重命名为 `leancloud-adapters-toutiao.js`。
@@ -760,7 +760,7 @@ $ npm install leancloud-realtime --save
 ```
 
 ```即时通讯（含富媒体消息）
-$ npm install leancloud-realtime leancloud-realtime-plugin-typed-messages@3 leancloud-storage --save
+$ npm install leancloud-realtime leancloud-realtime-plugin-typed-messages leancloud-storage --save
 ```
 
 #### 作为浏览器脚本引入

--- a/views/sdk_setup.tmpl
+++ b/views/sdk_setup.tmpl
@@ -234,9 +234,12 @@ const { Realtime, TextMessage } = require('leancloud-realtime');
 ```
 ```即时通讯（含富媒体消息）
 const AV = require('leancloud-storage');
-const { Realtime, TextMessage } = require('leancloud-realtime');
-// 富媒体消息插件暴露（export）的成员完整列表可以参考 [富媒体消息插件 API 文档](https://leancloud.github.io/js-realtime-sdk/plugins/typed-messages/docs/module-leancloud-realtime-plugin-typed-messages.html)。
-const { TypedMessagesPlugin, ImageMessage } = require('leancloud-realtime-plugin-typed-messages');
+const IM = require('leancloud-realtime');
+// 富媒体消息插件包含的消息类型可以参考 [富媒体消息插件 API 文档](https://leancloud.github.io/js-realtime-sdk/plugins/typed-messages/docs/module-leancloud-realtime-plugin-typed-messages.html)。
+const initPlugin = require('leancloud-realtime-plugin-typed-messages');
+
+const { Realtime, TextMessage } = IM;
+const { TypedMessagesPlugin, ImageMessage } = initPlugin(AV, IM);
 ```
 
 {{ docs.langSpecStart('即时通讯 即时通讯（含富媒体消息）') }}
@@ -333,7 +336,7 @@ Node.js 中 SDK 的安装与引用也是通过包管理工具 npm，请参考 [n
 
 前往 [即时通讯 SDK 下载页](https://releases.leanapp.cn/#/leancloud/js-realtime-sdk/releases)，下载最新版本的 `im.min.js`，移动到 `libs` 目录，并将文件重命名为 `leancloud-realtime.js`。
 
-下载 [`typed-messages.min.js`](https://code.bdstatic.com/npm/leancloud-realtime-plugin-typed-messages@3.1.0/dist/typed-messages.min.js)，移动到 `libs` 目录。必须保证<strong>三个文件在同一目录中</strong>。
+下载 [`typed-messages.min.js`](https://code.bdstatic.com/npm/leancloud-realtime-plugin-typed-messages@4/dist/typed-messages.min.js)，移动到 `libs` 目录。必须保证<strong>三个文件在同一目录中</strong>。
 {{ docs.langSpecEnd('即时通讯（含富媒体消息）') }}
 
 前往 [微信小程序 Adapters 下载页](https://unpkg.com/browse/@leancloud/platform-adapters-weapp/lib/)，下载最新版本的 `index.js`，移动到 `libs` 目录，并将文件重命名为 `leancloud-adapters-weapp.js`。
@@ -443,9 +446,12 @@ setAdapters(adapters);
 ```
 ```即时通讯（含富媒体消息）
 const AV = require('leancloud-storage/core');
-const { Realtime, setAdapters } = require('leancloud-realtime/im');
-const { TypedMessagesPlugin, ImageMessage } = require('leancloud-realtime-plugin-typed-messages');
+const IM = require('leancloud-realtime/im');
+const initPlugin = require('leancloud-realtime-plugin-typed-messages');
 const adapters = require('@leancloud/platform-adapters-alipay');
+
+const { Realtime, setAdapters } = IM;
+const { TypedMessagesPlugin, ImageMessage } = initPlugin(AV, IM);
 
 AV.setAdapters(adapters); // 为存储 SDK 设置 adapters
 setAdapters(adapters);    // 为即时通讯 SDK 设置 adapters
@@ -495,9 +501,12 @@ setAdapters(adapters);
 ```
 ```即时通讯（含富媒体消息）
 const AV = require('leancloud-storage/core');
-const { Realtime, setAdapters } = require('leancloud-realtime/im');
-const { TypedMessagesPlugin, ImageMessage } = require('leancloud-realtime-plugin-typed-messages');
+const IM = require('leancloud-realtime/im');
+const initPlugin = require('leancloud-realtime-plugin-typed-messages');
 const adapters = require('@leancloud/platform-adapters-baidu');
+
+const { Realtime, setAdapters } = IM;
+const { TypedMessagesPlugin, ImageMessage } = initPlugin(AV, IM);
 
 AV.setAdapters(adapters); // 为存储 SDK 设置 adapters
 setAdapters(adapters);    // 为即时通讯 SDK 设置 adapters
@@ -522,7 +531,7 @@ setAdapters(adapters);    // 为即时通讯 SDK 设置 adapters
 
 前往 [即时通讯 SDK 下载页](https://releases.leanapp.cn/#/leancloud/js-realtime-sdk/releases)，下载最新版本的 `im.min.js`，移动到 `libs` 目录，并将文件重命名为 `leancloud-realtime.js`。
 
-下载 [`typed-messages.min.js`](https://code.bdstatic.com/npm/leancloud-realtime-plugin-typed-messages@3.1.0/dist/typed-messages.min.js)，移动到 `libs` 目录。必须保证<strong>三个文件在同一目录中</strong>。
+下载 [`typed-messages.min.js`](https://code.bdstatic.com/npm/leancloud-realtime-plugin-typed-messages@4/dist/typed-messages.min.js)，移动到 `libs` 目录。必须保证<strong>三个文件在同一目录中</strong>。
 {{ docs.langSpecEnd('即时通讯（含富媒体消息）') }}
 
 前往 [字节跳动小程序 Adapters 下载页](https://code.bdstatic.com/npm/@leancloud/platform-adapters-toutiao@1.4.1/lib/index.js)，下载最新版本的 `index.js`，移动到 `libs` 目录，并将文件重命名为 `leancloud-adapters-toutiao.js`。
@@ -646,8 +655,12 @@ setAdapters(adapters);
 ```
 ```即时通讯（含富媒体消息）
 const AV = require('leancloud-storage/core');
-const { Realtime, setAdapters } = require('leancloud-realtime/im');
-const { TypedMessagesPlugin, ImageMessage } = require('leancloud-realtime-plugin-typed-messages');
+const IM = require('leancloud-realtime/im');
+const initPlugin = require('leancloud-realtime-plugin-typed-messages');
+
+const { Realtime, setAdapters } = IM;
+const { TypedMessagesPlugin, ImageMessage } = initPlugin(AV, IM);
+
 const adapters = require('@leancloud/platform-adapters-quickapp');
 AV.setAdapters(adapters);
 setAdapters(adapters);
@@ -718,9 +731,13 @@ setAdapters(adapters);
 ```
 ```即时通讯（含富媒体消息）
 import AV from 'leancloud-storage/core';
-import { Realtime, setAdapters } from 'leancloud-realtime/im';
-import { TypedMessagesPlugin, ImageMessage } from 'leancloud-realtime-plugin-typed-messages';
+import IM from 'leancloud-realtime/im';
+import initPlugin from 'leancloud-realtime-plugin-typed-messages';
 import * as adapters from '@leancloud/platform-adapters-react-native';
+
+const { Realtime, setAdapters } = IM;
+const { TypedMessagesPlugin, ImageMessage } = initPlugin(AV, IM);
+
 AV.setAdapters(adapters);
 setAdapters(adapters);
 ```
@@ -743,7 +760,7 @@ $ npm install leancloud-realtime --save
 ```
 
 ```即时通讯（含富媒体消息）
-$ npm install leancloud-realtime leancloud-realtime-plugin-typed-messages leancloud-storage --save
+$ npm install leancloud-realtime leancloud-realtime-plugin-typed-messages@3 leancloud-storage --save
 ```
 
 #### 作为浏览器脚本引入

--- a/views/weapp.md
+++ b/views/weapp.md
@@ -486,13 +486,15 @@ const realtime = getApp().realtime;
 
 1. 安装存储 SDK 至 `libs` 目录，并将文件重命名为 `leancloud-storage.js`。
 2. 安装即时通讯 SDK 至 `libs` 目录，并将文件重命名为 `leancloud-realtime.js`。
-3. 下载 [`leancloud-realtime-plugin-typed-messages.js`](https://unpkg.com/leancloud-realtime-plugin-typed-messages@^3.0.0)，移动到 `libs` 目录。必须保证<u>三个文件在同一目录中</u>。
+3. 下载 [`leancloud-realtime-plugin-typed-messages.js`](https://unpkg.com/leancloud-realtime-plugin-typed-messages@^4.0.0)，移动到 `libs` 目录。必须保证<u>三个文件在同一目录中</u>。
 4. 在 `app.js` 中<u>依次加载</u> `leancloud-storage.js`、`leancloud-realtime.js` 和 `leancloud-realtime-plugin-typed-messages.js`。
   ```javascript
   const AV = require('./libs/leancloud-storage.js');
-  const { Realtime, setAdapters } = require('./libs/leancloud-realtime.js');
-  const { TypedMessagesPlugin } = require('./libs/leancloud-realtime-plugin-typed-messages.js');
-  const { ImageMessage } = require('./libs/leancloud-realtime-plugin-typed-messages.js');
+  const IM = require('./libs/leancloud-realtime.js');
+  const initPlugin = require('./libs/leancloud-realtime-plugin-typed-messages.js');
+
+  const { Realtime, setAdapters } = IM;
+  const { TypedMessagesPlugin, ImageMessage } = initPlugin(AV, IM);
   ```
 5. 在 `app.js` 中初始化应用：
   ```javascript

--- a/views/weapp.md
+++ b/views/weapp.md
@@ -486,7 +486,7 @@ const realtime = getApp().realtime;
 
 1. 安装存储 SDK 至 `libs` 目录，并将文件重命名为 `leancloud-storage.js`。
 2. 安装即时通讯 SDK 至 `libs` 目录，并将文件重命名为 `leancloud-realtime.js`。
-3. 下载 [`leancloud-realtime-plugin-typed-messages.js`](https://unpkg.com/leancloud-realtime-plugin-typed-messages@^4.0.0)，移动到 `libs` 目录。必须保证<u>三个文件在同一目录中</u>。
+3. 下载 [`leancloud-realtime-plugin-typed-messages.js`](https://unpkg.com/leancloud-realtime-plugin-typed-messages@^4.0.0)，移动到 `libs` 目录。
 4. 在 `app.js` 中<u>依次加载</u> `leancloud-storage.js`、`leancloud-realtime.js` 和 `leancloud-realtime-plugin-typed-messages.js`。
   ```javascript
   const AV = require('./libs/leancloud-storage.js');


### PR DESCRIPTION
leancloud-realtime-plugin-typed-messages 发布了 4.0 ，解决由于插件内部使用的 SDK 与用户使用的 SDK 不匹配而导致的类型（AV.File，AV.GeoPoint）不匹配的问题。

~~改文档的过程中发现富媒体消息插件的 umd 命名空间也是 AV ，导致从 CDN 导入会覆盖整个 AV（富媒体插件只导出了一个函数），这个问题还没想好咋解决，所以 CDN 导入的部分还是使用 v3.1.0 。~~