### PR TITLE
delete unnecessary permissions

### DIFF
--- a/views/android_mixpush_guide.md
+++ b/views/android_mixpush_guide.md
@@ -778,9 +778,6 @@ dependencies {
 ```xml
 <uses-permission android:name="android.permission.INTERNET" />
 <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
-
-<uses-permission android:name="com.coloros.mcs.permission.RECIEVE_MCS_MESSAGE" />
-<uses-permission android:name="com.heytap.mcs.permission.RECIEVE_MCS_MESSAGE" />
 ```
 
 最后在 AndroidManifest 中添加必须的 service 与 receiver（开发者要将其中的 `com.vivo.push.app_id` 和 `com.vivo.push.app_key` 替换为自己的应用的信息）：


### PR DESCRIPTION
这两个是 OPPO 推送的权限，vivo 不需要。